### PR TITLE
ccontrol update node功能：

### DIFF
--- a/internal/ccontrol/CmdArgParser.go
+++ b/internal/ccontrol/CmdArgParser.go
@@ -25,6 +25,8 @@ import (
 
 var (
 	FlagNodeName      string
+	FlagState         string
+	FlagReason        string
 	FlagPartitionName string
 	FlagTaskId        uint32
 	FlagQueryAll      bool
@@ -102,6 +104,14 @@ var (
 			ChangeTaskTimeLimit(FlagTaskId, FlagTimeLimit)
 		},
 	}
+	updateNodeCmd = &cobra.Command{
+		Use:   "node",
+		Short: "Modify node information",
+		Long:  "",
+		Run: func(cmd *cobra.Command, args []string) {
+			ChangeNodeState(FlagNodeName, FlagState, FlagReason)
+		},
+	}
 )
 
 // ParseCmdArgs executes the root command.
@@ -119,6 +129,10 @@ func init() {
 	showCmd.AddCommand(showPartitionCmd)
 	showCmd.AddCommand(showTaskCmd)
 	rootCmd.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateNodeCmd)
+	updateNodeCmd.Flags().StringVarP(&FlagNodeName, "name", "n", "", "specify a node name")
+	updateNodeCmd.Flags().StringVarP(&FlagState, "state", "t", "", "specify the state")
+	updateNodeCmd.Flags().StringVarP(&FlagReason, "reason", "r", "", "set reason")
 	updateCmd.Flags().Uint32VarP(&FlagTaskId, "job", "J", 0, "Job id")
 	updateCmd.Flags().StringVarP(&FlagTimeLimit, "time-limit", "T", "", "time limit")
 	err := updateCmd.MarkFlagRequired("job")

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -236,3 +236,36 @@ func ChangeTaskTimeLimit(taskId uint32, timeLimit string) {
 		fmt.Printf("Chang time limit failed: %s\n", reply.GetReason())
 	}
 }
+
+func ChangeNodeState(nodeName string, state string, reason string) {
+
+	var req = &protos.ModifyNodeRequest{}
+	if nodeName == "" {
+		log.Fatalf("No valid node name in update node command.")
+	} else {
+		req.Name = nodeName
+	}
+	switch state {
+	case "drain":
+		if reason == "" {
+			log.Fatalf("You must specify a reason when DRAINING a node. Request denied")
+		}
+		req.Drain = true
+		req.Reason = reason
+	case "resume":
+		req.Drain = false
+	default:
+		log.Fatalf("Invalid state given: %s\n Request aborted \n Valid states are: drain, resume", state)
+	}
+
+	reply, err := stub.ModifyNode(context.Background(), req)
+	if err != nil {
+		panic("ModifyNode failed: " + err.Error())
+	}
+
+	if reply.Ok {
+		fmt.Println("Change node state success.")
+	} else {
+		fmt.Printf("Chang node state failed: %s\n", reply.GetReason())
+	}
+}

--- a/internal/cinfo/CmdArgParser.go
+++ b/internal/cinfo/CmdArgParser.go
@@ -32,6 +32,7 @@ var (
 	FlagFormat               string
 	FlagIterate              uint64
 	FlagConfigFilePath       string
+	FlagListReason           bool
 
 	RootCmd = &cobra.Command{
 		Use:   "cinfo",
@@ -66,8 +67,8 @@ func init() {
 		"Include craned nodes only with certain states. \n"+
 			"The state can take IDLE, MIX, ALLOC and DOWN and is case-insensitive. \n"+
 			"Example: \n"+
-			"\t -t idle,mix \n"+
-			"\t -t=alloc \n")
+			"\t -t IDLE,mIx \n"+
+			"\t -t=Alloc \n")
 	RootCmd.Flags().BoolVarP(&FlagFilterRespondingOnly, "responding", "r", false,
 		"report only responding nodes")
 	RootCmd.Flags().Uint64VarP(&FlagIterate, "iterate", "i", 0,
@@ -76,6 +77,8 @@ func init() {
 		"report state summary only")
 	RootCmd.Flags().StringVarP(&FlagFormat, "format", "o", "",
 		"format specification")
+	RootCmd.Flags().BoolVarP(&FlagListReason, "list-reasons", "R", false,
+		"list reason nodes are down or drained")
 
 	RootCmd.MarkFlagsMutuallyExclusive("states", "responding", "dead")
 }

--- a/internal/cinfo/cinfo.go
+++ b/internal/cinfo/cinfo.go
@@ -50,6 +50,8 @@ func cinfoFunc() {
 				stateList = append(stateList, protos.CranedState_CRANE_ALLOC)
 			case "down":
 				stateList = append(stateList, protos.CranedState_CRANE_DOWN)
+			case "drain":
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN)
 			default:
 				log.Fatalf("Invalid state given: %s\n", FlagFilterCranedStates[i])
 			}

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -274,6 +274,17 @@ message ModifyTaskReply {
   string reason = 2;
 }
 
+message ModifyNodeRequest{
+  string name = 1;
+  bool drain = 2;
+  string reason =3;
+}
+
+message ModifyNodeReply{
+  bool ok = 1;
+  string reason=2;
+}
+
 message AddAccountRequest {
   uint32 uid = 1;
   AccountInfo account = 2;
@@ -583,6 +594,7 @@ service CraneCtld {
   rpc QueryCranedInfo(QueryCranedInfoRequest) returns (QueryCranedInfoReply);
   rpc QueryPartitionInfo(QueryPartitionInfoRequest) returns (QueryPartitionInfoReply);
   rpc ModifyTask(ModifyTaskRequest) returns (ModifyTaskReply);
+  rpc ModifyNode(ModifyNodeRequest) returns (ModifyNodeReply);
 
   /* RPCs called from cacctmgr */
   rpc AddAccount(AddAccountRequest) returns (AddAccountReply);

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -52,6 +52,7 @@ enum CranedState{
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
+  CRANE_DRAIN =4;
 }
 
 enum TaskStatus {


### PR DESCRIPTION
更改节点状态为drain，该节点不会有新的作业被调度，当前运行的作业不受影响；
-n指定节点名
--state指定状态为drain/resume，指定为drain时需用--reason说明原因。
--state=resume恢复节点drain之前的状态
cinfo查询节点状态时增加状态drain，state过滤也增加drain