### PR TITLE
feat: Add robust time parsing for cacct

### DIFF
--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -43,19 +43,18 @@ const (
 func QueryJob() {
 	request := protos.QueryTasksInfoRequest{OptionIncludeCompletedTasks: true}
 
-	timeFormat := "2006-01-02T15:04:05"
 	if FlagFilterStartTime != "" {
 		request.FilterStartTimeInterval = &protos.TimeInterval{}
 		split := strings.Split(FlagFilterStartTime, "~")
 		if split[0] != "" {
-			tl, err := time.Parse(timeFormat, split[0])
+			tl, err := util.ParseTime(split[0])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}
 			request.FilterStartTimeInterval.LowerBound = timestamppb.New(tl)
 		}
 		if len(split) >= 2 && split[1] != "" {
-			tr, err := time.Parse(timeFormat, split[1])
+			tr, err := util.ParseTime(split[1])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}
@@ -66,14 +65,14 @@ func QueryJob() {
 		request.FilterEndTimeInterval = &protos.TimeInterval{}
 		split := strings.Split(FlagFilterEndTime, "~")
 		if split[0] != "" {
-			tl, err := time.Parse(timeFormat, split[0])
+			tl, err := util.ParseTime(split[0])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}
 			request.FilterEndTimeInterval.LowerBound = timestamppb.New(tl)
 		}
 		if len(split) >= 2 && split[1] != "" {
-			tr, err := time.Parse(timeFormat, split[1])
+			tr, err := util.ParseTime(split[1])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}
@@ -84,14 +83,14 @@ func QueryJob() {
 		request.FilterSubmitTimeInterval = &protos.TimeInterval{}
 		split := strings.Split(FlagFilterSubmitTime, "~")
 		if split[0] != "" {
-			tl, err := time.Parse(timeFormat, split[0])
+			tl, err := util.ParseTime(split[0])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}
 			request.FilterSubmitTimeInterval.LowerBound = timestamppb.New(tl)
 		}
 		if len(split) >= 2 && split[1] != "" {
-			tr, err := time.Parse(timeFormat, split[1])
+			tr, err := util.ParseTime(split[1])
 			if err != nil {
 				log.Fatalf("Failed to parse the time string: %s", err)
 			}

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 func ParseMemStringAsByte(mem string) (uint64, error) {
@@ -65,6 +66,20 @@ func ParseDuration(time string, duration *duration.Duration) bool {
 
 	duration.Seconds = int64(60*60*hh + 60*mm + ss)
 	return true
+}
+
+func ParseTime(ts string) (time.Time, error) {
+	// Try to parse the timezone at first
+	layout := time.RFC3339
+	parsed, err := time.Parse(layout, ts)
+	if err == nil {
+		return parsed, nil
+	}
+
+	// Fallback to the short layout, assuming local timezone
+	layoutShort := time.RFC3339[:19]
+	parsed, err = time.ParseInLocation(layoutShort, ts, time.Local)
+	return parsed, err
 }
 
 func SecondTimeFormat(second int64) string {


### PR DESCRIPTION
实现了一个统一的时间格式解析函数：

1. 统一使用 RFC 3339 时间格式。
2. 在用户没有明确时区时，默认使用本机时区。
