### PR TITLE
fix --get-user-env cmd.

### DIFF
--- a/internal/cbatch/CmdArgParser.go
+++ b/internal/cbatch/CmdArgParser.go
@@ -37,7 +37,7 @@ var (
 	FlagRepeat        uint32
 	FlagNodelist      string
 	FlagExcludes      string
-	FlagGetUserEnv    string
+	FlagGetUserEnv    bool
 	FlagExport        string
 	FlagStdoutPath    string
 	FlagStderrPath    string
@@ -81,7 +81,7 @@ func init() {
 	RootCmd.Flags().Uint32Var(&FlagRepeat, "repeat", 1, "submit the task multiple times")
 	RootCmd.Flags().StringVarP(&FlagNodelist, "nodelist", "w", "", "List of specific nodes to be allocated to the job, separated by commas")
 	RootCmd.Flags().StringVarP(&FlagExcludes, "exclude", "x", "", "exclude a specific list of hosts, separated by commas")
-	RootCmd.Flags().StringVar(&FlagGetUserEnv, "get-user-env", "", "get user's environment variables")
+	RootCmd.Flags().BoolVar(&FlagGetUserEnv, "get-user-env", false, "load login environment variables")
 	RootCmd.Flags().StringVar(&FlagExport, "export", "", "propagate environment variables")
 	RootCmd.Flags().StringVarP(&FlagStdoutPath, "output", "o", "", "file for batch script's standard output")
 	RootCmd.Flags().StringVarP(&FlagStderrPath, "error", "e", "", "file for batch script's standard error output")

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -175,7 +175,7 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 	if FlagExcludes != "" {
 		task.Excludes = FlagExcludes
 	}
-	if FlagGetUserEnv != "" {
+	if FlagGetUserEnv {
 		task.GetUserEnv = true
 	}
 	if FlagExport != "" {


### PR DESCRIPTION
--get-user-env 的命令行解析有误，之前写法需要带参数，实际上不需要。
现在支持的写法：
--get-user-env
--get-user-env=0/1/t/f
不支持的写法：
--get-user-env=123