### PR TITLE
sync --get-user-env script arg format with cmd.

### DIFF
--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -126,7 +126,12 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 		case "-e", "--error":
 			task.GetBatchMeta().ErrorFilePattern = arg.val
 		case "--mail-type":
-			task.MailType = util.ParseMailType(arg.val)
+			mailType, err := util.ParseMailType(arg.val)
+			if err != nil {
+				log.Error(err)
+				return false, nil
+			}
+			task.MailType = mailType
 		case "--mail-user":
 			task.MailUser = arg.val
 		default:
@@ -197,7 +202,12 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 		task.GetBatchMeta().ErrorFilePattern = FlagStderrPath
 	}
 	if FlagMailType != "" {
-		task.MailType = util.ParseMailType(FlagMailType)
+		mailType, err := util.ParseMailType(FlagMailType)
+		if err != nil {
+			log.Error(err)
+			return false, nil
+		}
+		task.MailType = mailType
 	}
 	if FlagMailUser != "" {
 		task.MailUser = FlagMailUser

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -217,11 +217,11 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 		log.Print("Invalid --cpus-per-task, --ntasks-per-node or --node-num")
 		return false, nil
 	}
-	if !CheckNodeList(task.Nodelist) {
+	if !util.CheckNodeList(task.Nodelist) {
 		log.Print("Invalid --nodelist")
 		return false, nil
 	}
-	if !CheckNodeList(task.Excludes) {
+	if !util.CheckNodeList(task.Excludes) {
 		log.Print("Invalid --exclude")
 		return false, nil
 	}
@@ -234,15 +234,6 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 	task.Resources.AllocatableResource.CpuCoreLimit = task.CpusPerTask * float64(task.NtasksPerNode)
 
 	return true, task
-}
-
-func CheckNodeList(nodeStr string) bool {
-	nameStr := strings.ReplaceAll(nodeStr, " ", "")
-	if nameStr == "" {
-		return true
-	}
-	re := regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9]*[0-9])(,([a-zA-Z][a-zA-Z0-9]*[0-9]))*$`)
-	return re.MatchString(nameStr)
 }
 
 func SendRequest(task *protos.TaskToCtld) util.CraneCmdError {

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -109,7 +109,16 @@ func ProcessCbatchArg(args []CbatchArg) (bool, *protos.TaskToCtld) {
 		case "--nodelist", "-w":
 			task.Nodelist = arg.val
 		case "--get-user-env":
-			task.GetUserEnv = true
+			if arg.val == "" {
+				task.GetUserEnv = true
+			} else {
+				val, err := strconv.ParseBool(arg.val)
+				if err != nil {
+					log.Print("Invalid " + arg.name)
+					return false, nil
+				}
+				task.GetUserEnv = val
+			}
 		case "--export":
 			task.Env["CRANE_EXPORT_ENV"] = arg.val
 		case "-o", "--output":

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -143,6 +143,17 @@ func ParseMailType(param string) (uint32, error) {
 	return parsed, nil
 }
 
+// CheckNodeList check if the node list is comma separated node names.
+// The node name should contain only letters and numbers, and start with a letter, end with a number.
+func CheckNodeList(nodeStr string) bool {
+	nameStr := strings.ReplaceAll(nodeStr, " ", "")
+	if nameStr == "" {
+		return true
+	}
+	re := regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9]*[0-9])(,([a-zA-Z][a-zA-Z0-9]*[0-9]))*$`)
+	return re.MatchString(nameStr)
+}
+
 func ParseHostList(hostStr string) ([]string, bool) {
 	nameStr := strings.ReplaceAll(hostStr, " ", "")
 	nameStr += ","

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -115,7 +115,7 @@ func ParseFloatWithPrecision(val string, decimalPlaces int) (float64, error) {
 	return math.Floor(num*shift) / shift, nil
 }
 
-func ParseMailType(param string) uint32 {
+func ParseMailType(param string) (uint32, error) {
 	var MailTypeMapping = map[string]uint32{
 		"NONE":           0,
 		"BEGIN":          1,
@@ -135,9 +135,12 @@ func ParseMailType(param string) uint32 {
 	parsed := uint32(0)
 	types := strings.Split(param, ",")
 	for _, t := range types {
+		if _, ok := MailTypeMapping[t]; !ok {
+			return 0, fmt.Errorf("invalid mail type: %s", t)
+		}
 		parsed |= MailTypeMapping[t]
 	}
-	return parsed
+	return parsed, nil
 }
 
 func ParseHostList(hostStr string) ([]string, bool) {


### PR DESCRIPTION
修改 --get-user-env 命令行解析方式后于脚本解析参数不一致，故修改，同时增加了 mail-type 参数的校验，错误参数将报错。