### PR TITLE
feat: diff drain state.

### DIFF
--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -352,7 +352,7 @@ func ChangeNodeState(nodeName string, state string, reason string) util.CraneCmd
 			log.Errorln("You must specify a reason by '-r' or '--reason' when draining a node.")
 			return util.ErrorCmdArg
 		}
-		req.NewState = protos.CranedState_CRANE_DRAIN
+		req.NewState = protos.CranedState_CRANE_DRAIN_IDLE
 		req.Reason = reason
 	case "resume":
 		req.NewState = protos.CranedState_CRANE_IDLE

--- a/internal/cinfo/CmdArgParser.go
+++ b/internal/cinfo/CmdArgParser.go
@@ -71,7 +71,7 @@ func init() {
 		"Display the specified nodes only")
 	RootCmd.Flags().StringSliceVarP(&FlagFilterCranedStates, "states", "t", nil,
 		"Display nodes with the specified states only. \n"+
-			"The state can take IDLE, MIX, ALLOC and DOWN (case-insensitive). \n"+
+			"The state can take IDLE, MIX, ALLOC, DOWN, DRAIN_IDLE, DRAIN_MIX, DRAIN_ALLOC and DRAIN(case-insensitive). \n"+
 			"Example: \n"+
 			"\t -t idle,mix \n"+
 			"\t -t=alloc \n")

--- a/internal/cinfo/cinfo.go
+++ b/internal/cinfo/cinfo.go
@@ -46,8 +46,16 @@ func cinfoFunc() util.CraneCmdError {
 				stateList = append(stateList, protos.CranedState_CRANE_ALLOC)
 			case "down":
 				stateList = append(stateList, protos.CranedState_CRANE_DOWN)
+			case "drain_idle":
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_IDLE)
+			case "drain_mix":
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_MIX)
+			case "drain_alloc":
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_ALLOC)
 			case "drain":
-				stateList = append(stateList, protos.CranedState_CRANE_DRAIN)
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_IDLE)
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_MIX)
+				stateList = append(stateList, protos.CranedState_CRANE_DRAIN_ALLOC)
 			default:
 				log.Errorf("Invalid state given: %s.\n", FlagFilterCranedStates[i])
 				return util.ErrorCmdArg
@@ -58,7 +66,7 @@ func cinfoFunc() util.CraneCmdError {
 	} else if FlagFilterDownOnly {
 		stateList = append(stateList, protos.CranedState_CRANE_DOWN)
 	} else {
-		stateList = append(stateList, protos.CranedState_CRANE_IDLE, protos.CranedState_CRANE_MIX, protos.CranedState_CRANE_ALLOC, protos.CranedState_CRANE_DOWN, protos.CranedState_CRANE_DRAIN)
+		stateList = append(stateList, protos.CranedState_CRANE_IDLE, protos.CranedState_CRANE_MIX, protos.CranedState_CRANE_ALLOC, protos.CranedState_CRANE_DOWN, protos.CranedState_CRANE_DRAIN_IDLE, protos.CranedState_CRANE_DRAIN_MIX, protos.CranedState_CRANE_DRAIN_ALLOC)
 	}
 
 	var nodeList []string

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -52,7 +52,9 @@ enum CranedState {
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
-  CRANE_DRAIN = 4;
+  CRANE_DRAIN_IDLE = 4;
+  CRANE_DRAIN_MIX = 5;
+  CRANE_DRAIN_ALLOC = 6;
 }
 
 enum TaskStatus {


### PR DESCRIPTION
区分了 drain 状态下的 idle/mix/alloc 节点（不区分 down 节点），查询时支持使用 drain 筛选所有 drain 节点或使用 drain_idle 筛选所有 drain 且无任务节点。