### PR TITLE
Feat: Use elapsed time from backend

### DIFF
--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -353,7 +353,7 @@ func main(cmd *cobra.Command, args []string) {
 	task := &protos.TaskToCtld{
 		Name:          "Interactive",
 		TimeLimit:     util.InvalidDuration(),
-		PartitionName: "CPU",
+		PartitionName: "",
 		Resources: &protos.Resources{
 			AllocatableResource: &protos.AllocatableResource{
 				CpuCoreLimit:       1,

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -163,7 +163,7 @@ func ShowTasks(taskId uint32, queryAll bool) util.CraneCmdError {
 			runTimeStr := "unknown"
 			if !timeStart.Before(time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)) {
 				timeStartStr = timeStart.In(time.Local).Format("2006-01-02 15:04:05")
-				runTimeDuration := time.Since(timeStart)
+				runTimeDuration := taskInfo.ElapsedTime.AsDuration()
 
 				days := int(runTimeDuration.Hours()) / 24
 				hours := int(runTimeDuration.Hours()) % 24

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -106,7 +106,6 @@ func Query() util.CraneCmdError {
 		return util.ErrorNetwork
 	}
 
-	now := time.Now()
 	table := tablewriter.NewWriter(os.Stdout)
 	util.SetBorderlessTable(table)
 	header := []string{"JobId", "Partition", "Name", "User",
@@ -122,8 +121,7 @@ func Query() util.CraneCmdError {
 
 		var timeElapsedStr string
 		if reply.TaskInfoList[i].Status == protos.TaskStatus_Running {
-			elapsed := now.Sub(reply.TaskInfoList[i].StartTime.AsTime())
-			timeElapsedStr = util.SecondTimeFormat(int64(elapsed.Seconds()))
+			timeElapsedStr = util.SecondTimeFormat(reply.TaskInfoList[i].ElapsedTime.Seconds)
 		} else {
 			timeElapsedStr = "-"
 		}

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -528,7 +528,7 @@ func MainCrun(cmd *cobra.Command, args []string) {
 	task := &protos.TaskToCtld{
 		Name:          "Interactive",
 		TimeLimit:     util.InvalidDuration(),
-		PartitionName: "CPU",
+		PartitionName: "",
 		Resources: &protos.Resources{
 			AllocatableResource: &protos.AllocatableResource{
 				CpuCoreLimit:       1,

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -218,6 +218,7 @@ message TaskInfo {
     string pending_reason = 35;
     string craned_list = 36;
   }
+  google.protobuf.Duration elapsed_time = 37;
 }
 
 message PartitionInfo {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -218,6 +218,11 @@ message TaskInfo {
     string pending_reason = 35;
     string craned_list = 36;
   }
+
+  // The time of different nodes across the whole cluster might not always be synchronized.
+  // If the time on the front end node is more than several seconds ahead of the CraneCtld node,
+  // a negative elapsed time might occur.
+  // To avoid this, the elapsed time of a task is calculated on the CraneCtld side.
   google.protobuf.Duration elapsed_time = 37;
 }
 


### PR DESCRIPTION
Fix `TIME` displaying negative duration when time in the cluster is unsynced.