### PR TITLE
feat: add CranedControlState (NONE, DRAIN)

### DIFF
--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -52,10 +52,14 @@ func ShowNodes(nodeName string, queryAll bool) util.CraneCmdError {
 			fmt.Println("No node is available.")
 		} else {
 			for _, nodeInfo := range reply.CranedInfoList {
+				stateStr := strings.ToLower(nodeInfo.ResourceState.String()[6:])
+				if nodeInfo.ControlState != protos.CranedControlState_CRANE_NONE {
+					stateStr += "(" + strings.ToLower(nodeInfo.ControlState.String()[6:]) + ")"
+				}
 				fmt.Printf("NodeName=%v State=%v CPU=%.2f AllocCPU=%.2f FreeCPU=%.2f\n"+
 					"\tRealMemory=%dM AllocMem=%dM FreeMem=%dM\n"+
 					"\tPatition=%s RunningJob=%d\n\n",
-					nodeInfo.Hostname, nodeInfo.State.String()[6:], nodeInfo.Cpu,
+					nodeInfo.Hostname, stateStr, nodeInfo.Cpu,
 					math.Abs(nodeInfo.AllocCpu),
 					math.Abs(nodeInfo.FreeCpu),
 					nodeInfo.RealMem/B2MBRatio, nodeInfo.AllocMem/B2MBRatio, nodeInfo.FreeMem/B2MBRatio,
@@ -67,10 +71,14 @@ func ShowNodes(nodeName string, queryAll bool) util.CraneCmdError {
 			fmt.Printf("Node %s not found.\n", nodeName)
 		} else {
 			for _, nodeInfo := range reply.CranedInfoList {
+				stateStr := strings.ToLower(nodeInfo.ResourceState.String()[6:])
+				if nodeInfo.ControlState != protos.CranedControlState_CRANE_NONE {
+					stateStr += "(" + strings.ToLower(nodeInfo.ControlState.String()[6:]) + ")"
+				}
 				fmt.Printf("NodeName=%v State=%v CPU=%.2f AllocCPU=%.2f FreeCPU=%.2f\n"+
 					"\tRealMemory=%dM AllocMem=%dM FreeMem=%dM\n"+
 					"\tPatition=%s RunningJob=%d\n\n",
-					nodeInfo.Hostname, nodeInfo.State.String()[6:], nodeInfo.Cpu, nodeInfo.AllocCpu, nodeInfo.FreeCpu,
+					nodeInfo.Hostname, stateStr, nodeInfo.Cpu, nodeInfo.AllocCpu, nodeInfo.FreeCpu,
 					nodeInfo.RealMem/B2MBRatio, nodeInfo.AllocMem/B2MBRatio, nodeInfo.FreeMem/B2MBRatio,
 					strings.Join(nodeInfo.PartitionNames, ","), nodeInfo.RunningTaskNum)
 			}
@@ -351,10 +359,10 @@ func ChangeNodeState(nodeName string, state string, reason string) util.CraneCmd
 			log.Errorln("You must specify a reason by '-r' or '--reason' when draining a node.")
 			return util.ErrorCmdArg
 		}
-		req.NewState = protos.CranedState_CRANE_DRAIN
+		req.NewState = protos.CranedControlState_CRANE_DRAIN
 		req.Reason = reason
 	case "resume":
-		req.NewState = protos.CranedState_CRANE_IDLE
+		req.NewState = protos.CranedControlState_CRANE_NONE
 	default:
 		log.Errorf("Invalid state given: %s. Valid states are: drain, resume.\n", state)
 		return util.ErrorCmdArg

--- a/internal/cinfo/cinfo.go
+++ b/internal/cinfo/cinfo.go
@@ -34,31 +34,38 @@ func cinfoFunc() util.CraneCmdError {
 	config := util.ParseConfig(FlagConfigFilePath)
 	stub := util.GetStubToCtldByConfig(config)
 
-	var stateList []protos.CranedState
-	if len(FlagFilterCranedStates) != 0 {
-		for i := 0; i < len(FlagFilterCranedStates); i++ {
-			switch strings.ToLower(FlagFilterCranedStates[i]) {
-			case "idle":
-				stateList = append(stateList, protos.CranedState_CRANE_IDLE)
-			case "mix":
-				stateList = append(stateList, protos.CranedState_CRANE_MIX)
-			case "alloc":
-				stateList = append(stateList, protos.CranedState_CRANE_ALLOC)
-			case "down":
-				stateList = append(stateList, protos.CranedState_CRANE_DOWN)
-			case "drain":
-				stateList = append(stateList, protos.CranedState_CRANE_DRAIN)
-			default:
-				log.Errorf("Invalid state given: %s.\n", FlagFilterCranedStates[i])
-				return util.ErrorCmdArg
-			}
+	var resourceStateList []protos.CranedResourceState
+	var controlStateList []protos.CranedControlState
+	for i := 0; i < len(FlagFilterCranedStates); i++ {
+		switch strings.ToLower(FlagFilterCranedStates[i]) {
+		case "idle":
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_IDLE)
+		case "mix":
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_MIX)
+		case "alloc":
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_ALLOC)
+		case "down":
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_DOWN)
+		case "none":
+			controlStateList = append(controlStateList, protos.CranedControlState_CRANE_NONE)
+		case "drain":
+			controlStateList = append(controlStateList, protos.CranedControlState_CRANE_DRAIN)
+		default:
+			log.Errorf("Invalid state given: %s.\n", FlagFilterCranedStates[i])
+			return util.ErrorCmdArg
 		}
-	} else if FlagFilterRespondingOnly {
-		stateList = append(stateList, protos.CranedState_CRANE_IDLE, protos.CranedState_CRANE_MIX, protos.CranedState_CRANE_ALLOC)
-	} else if FlagFilterDownOnly {
-		stateList = append(stateList, protos.CranedState_CRANE_DOWN)
-	} else {
-		stateList = append(stateList, protos.CranedState_CRANE_IDLE, protos.CranedState_CRANE_MIX, protos.CranedState_CRANE_ALLOC, protos.CranedState_CRANE_DOWN, protos.CranedState_CRANE_DRAIN)
+	}
+	if len(resourceStateList) == 0 {
+		if FlagFilterRespondingOnly {
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_IDLE, protos.CranedResourceState_CRANE_MIX, protos.CranedResourceState_CRANE_ALLOC)
+		} else if FlagFilterDownOnly {
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_DOWN)
+		} else {
+			resourceStateList = append(resourceStateList, protos.CranedResourceState_CRANE_IDLE, protos.CranedResourceState_CRANE_MIX, protos.CranedResourceState_CRANE_ALLOC, protos.CranedResourceState_CRANE_DOWN)
+		}
+	}
+	if len(controlStateList) == 0 {
+		controlStateList = append(controlStateList, protos.CranedControlState_CRANE_NONE, protos.CranedControlState_CRANE_DRAIN)
 	}
 
 	var nodeList []string
@@ -84,9 +91,10 @@ func cinfoFunc() util.CraneCmdError {
 	}
 
 	req := &protos.QueryClusterInfoRequest{
-		FilterPartitions:   partList,
-		FilterNodes:        nodeList,
-		FilterCranedStates: stateList,
+		FilterPartitions:           partList,
+		FilterNodes:                nodeList,
+		FilterCranedResourceStates: resourceStateList,
+		FilterCranedControlStates:  controlStateList,
 	}
 
 	reply, err := stub.QueryClusterInfo(context.Background(), req)
@@ -102,12 +110,16 @@ func cinfoFunc() util.CraneCmdError {
 	for _, partitionCraned := range reply.Partitions {
 		for _, commonCranedStateList := range partitionCraned.CranedLists {
 			if commonCranedStateList.Count > 0 {
+				stateStr := strings.ToLower(commonCranedStateList.ResourceState.String()[6:])
+				if commonCranedStateList.ControlState != protos.CranedControlState_CRANE_NONE {
+					stateStr += "(" + strings.ToLower(commonCranedStateList.ControlState.String()[6:]) + ")"
+				}
 				tableData = append(tableData, []string{
 					partitionCraned.Name,
 					strings.ToLower(partitionCraned.State.String()[10:]),
 					"infinite",
 					strconv.FormatUint(uint64(commonCranedStateList.Count), 10),
-					strings.ToLower(commonCranedStateList.State.String()[6:]),
+					stateStr,
 					commonCranedStateList.CranedListRegex,
 				})
 			}

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -214,7 +214,7 @@ message ModifyTaskReply {
 
 message ModifyCranedStateRequest{
   string craned_id = 1;
-  CranedState new_state = 2;
+  CranedControlState new_state = 2;
   string reason = 3;
 }
 
@@ -329,7 +329,8 @@ message MigrateSshProcToCgroupReply {
 message QueryClusterInfoRequest {
   repeated string filter_partitions = 1;
   repeated string filter_nodes = 2;
-  repeated CranedState filter_craned_states = 3;
+  repeated CranedResourceState filter_craned_resource_states = 3;
+  repeated CranedControlState filter_craned_control_states = 4;
 }
 
 message QueryClusterInfoReply {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -47,12 +47,16 @@ enum PartitionState {
   PARTITION_DOWN = 1;
 }
 
-enum CranedState {
+enum CranedResourceState {
   CRANE_IDLE = 0;
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
-  CRANE_DRAIN = 4;
+}
+
+enum CranedControlState {
+  CRANE_NONE = 0;
+  CRANE_DRAIN = 1;
 }
 
 enum TaskStatus {
@@ -243,22 +247,24 @@ message PartitionInfo {
 
 message CranedInfo {
   string hostname = 1;
-  CranedState state = 2;
-  double cpu = 3;
-  double alloc_cpu = 4;
-  double free_cpu = 5;
-  uint64 real_mem = 6;
-  uint64 alloc_mem = 7;
-  uint64 free_mem = 8;
-  repeated string partition_names = 9;
-  uint32 running_task_num = 10;
+  CranedResourceState resource_state = 2;
+  CranedControlState control_state = 3;
+  double cpu = 4;
+  double alloc_cpu = 5;
+  double free_cpu = 6;
+  uint64 real_mem = 7;
+  uint64 alloc_mem = 8;
+  uint64 free_mem = 9;
+  repeated string partition_names = 10;
+  uint32 running_task_num = 11;
 }
 
 message TrimmedPartitionInfo {
   message TrimmedCranedInfo {
-    CranedState state = 1;
-    uint32 count = 2;
-    string craned_list_regex = 3;
+    CranedResourceState resource_state = 1;
+    CranedControlState control_state = 2;
+    uint32 count = 3;
+    string craned_list_regex = 4;
   }
 
   string name = 1;


### PR DESCRIPTION
将 drain 这一状态与资源状态 (idle, mix, alloc, down）分离，独立为控制状态（none, drain）。
查询时支持按照两类状态分别筛选，单种状态内取并集，两种状态间取交集。
修改节点时只使用控制状态。

本 pr 应取代 #108 