### PR TITLE
feat: Add prefix, padding and suffix support for format string

### DIFF
--- a/internal/cacct/CmdArgParser.go
+++ b/internal/cacct/CmdArgParser.go
@@ -107,29 +107,27 @@ func init() {
 		"Specify partitions to view (comma separated list), default is all")
 
 	RootCmd.Flags().StringVarP(&FlagFormat, "format", "o", "",
-		`Specify the output format for the command. 
+		`Specify the output format.
 Fields are identified by a percent sign (%) followed by a character. 
 Use a dot (.) and a number between % and the format character to specify a minimum width for the field. 
 
 Supported format identifiers:
-	%j: JobId     - Displays the ID of the job. Optionally, use %.<width>j to specify a fixed width.
-	%n: JobName   - Displays the name of the job.
-	%P: Partition - Displays the partition associated with the job.
 	%a: Account   - Displays the account associated with the job.
 	%c: AllocCPUs - Displays the number of allocated CPUs, formatted to two decimal places.
-	%t: State     - Displays the state of the job.
 	%e: ExitCode  - Displays the exit code of the job. 
-                    If the exit code is based on a specific base (e.g., kCraneExitCodeBase),
-                    it formats as "0:<code>" or "<code>:0" based on the condition.
-		
-Example:
---format "%j %.10n %P %a %.2c %t %e" would output
-the job’s ID, Name with a minimum width of 10, Partition, Account, 
-Allocated CPUs with two decimal places, State, and Exit Code.
+					If the exit code is based on a specific base (e.g., kCraneExitCodeBase),
+					it formats as "0:<code>" or "<code>:0" based on the condition.
+	%j: JobID     - Displays the ID of the job.
+	%n: Name   - Displays the name of the job.
+	%P: Partition - Displays the partition associated with the job.
+	%t: State     - Displays the state of the job.
 
-Each part of the format string controls the appearance of the corresponding column in the output table. 
+Each format specifier can be modified with a width specifier (e.g., "%.5j").
 If the width is specified, the field will be formatted to at least that width. 
 If the format is invalid or unrecognized, the program will terminate with an error message.
+
+Example: --format "%.5j %.20n %t" would output the job's ID with a minimum width of 5,
+         Name with a minimum width of 20, and the State.
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false, "Display full information (If not set, only display 30 characters per cell)")
 	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 0,

--- a/internal/cqueue/CmdArgParser.go
+++ b/internal/cqueue/CmdArgParser.go
@@ -106,19 +106,19 @@ Use a dot (.) and a number between % and the format character to specify a minim
 
 Supported format identifiers:
 	%a: Account    - Display the account associated with the job.
-    %e: Time       - Display the elapsed time from the start of the job. 
+	%e: Time       - Display the elapsed time from the start of the job. 
 	%j: JobID      - Display the ID of the job.
-    %l: TimeLimit  - Display the time limit for the job.
-    %L: NodeList   - Display the list of nodes the job is running on.
-    %n: Name       - Display the name of the job.
-    %N: Nodes      - Display the number of nodes assigned to the job.
-    %p: Priority   - Display the job's priority.
-    %P: Partition  - Display the partition the job is running in.
-    %q: QoS        - Display the Quality of Service level for the job.
-    %s: SubmitTime - Display the submission time of the job.
-    %t: State      - Display the current state of the job.
-    %T: Type       - Display the job type.
-    %u: User       - Display the user who submitted the job.
+	%l: TimeLimit  - Display the time limit for the job.
+	%L: NodeList   - Display the list of nodes the job is running on.
+	%n: Name       - Display the name of the job.
+	%N: Nodes      - Display the number of nodes assigned to the job.
+	%p: Priority   - Display the job's priority.
+	%P: Partition  - Display the partition the job is running in.
+	%q: QoS        - Display the Quality of Service level for the job.
+	%s: SubmitTime - Display the submission time of the job.
+	%t: State      - Display the current state of the job.
+	%T: Type       - Display the job type.
+	%u: User       - Display the user who submitted the job.
 
 Each format specifier can be modified with a width specifier (e.g., "%.5j").
 If the width is specified, the field will be formatted to at least that width. 

--- a/internal/cqueue/CmdArgParser.go
+++ b/internal/cqueue/CmdArgParser.go
@@ -105,23 +105,27 @@ Fields are identified by a percent sign (%) followed by a character.
 Use a dot (.) and a number between % and the format character to specify a minimum width for the field. 
 
 Supported format identifiers:
-    %j: JobID     - Display the job ID of the task. Use "%.5j" for a width of 5.
-    %n: Name      - Display the name of the task.
-    %t: Status    - Display the current status of the task.
-    %P: Partition - Display the partition the task is running in.
-    %p: Priority  - Display the task's priority.
-    %u: User      - Display the user who submitted the task.
-    %a: Account   - Display the account associated with the task.
-    %T: Type      - Display the task type.
-    %I: NodeList  - Display the list of nodes the task is running on.
-    %l: TimeLimit - Display the time limit for the task.
-    %N: Nodes     - Display the number of nodes assigned to the task.
-    %s: SubmitTime- Display the submission time of the task.
-    %q: QoS       - Display the Quality of Service level for the task.
+	%a: Account    - Display the account associated with the job.
+    %e: Time       - Display the elapsed time from the start of the job. 
+	%j: JobID      - Display the ID of the job.
+    %l: TimeLimit  - Display the time limit for the job.
+    %L: NodeList   - Display the list of nodes the job is running on.
+    %n: Name       - Display the name of the job.
+    %N: Nodes      - Display the number of nodes assigned to the job.
+    %p: Priority   - Display the job's priority.
+    %P: Partition  - Display the partition the job is running in.
+    %q: QoS        - Display the Quality of Service level for the job.
+    %s: SubmitTime - Display the submission time of the job.
+    %t: State      - Display the current state of the job.
+    %T: Type       - Display the job type.
+    %u: User       - Display the user who submitted the job.
 
 Each format specifier can be modified with a width specifier (e.g., "%.5j").
-Example: --format "%.5j %.20n %t" will output tasks' JobID with a minimum width of 5,
-         Name with a minimum width of 20, and Status.
+If the width is specified, the field will be formatted to at least that width. 
+If the format is invalid or unrecognized, the program will terminate with an error message.
+
+Example: --format "%.5j %.20n %t" would output Jobs' ID with a minimum width of 5,
+         Name with a minimum width of 20, and the State.
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false, "Display full information (If not set, only display 30 characters per cell)")
 	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 0,


### PR DESCRIPTION
This PR adds support for more complex format string for cqueue and cacct.
For example, the format string could be: 
- `S0mePref1x%10n, SomePaddingsXXX___%.5jAND_...SoM3SUFF1X`.