### PR TITLE
Feat(cbatch): trim file path

### DIFF
--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -31,6 +31,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const FILE_MAX = 255
+
 type CbatchArg struct {
 	name string
 	val  string
@@ -255,6 +257,20 @@ func ProcessCbatchArgs(cmd *cobra.Command, args []CbatchArg) (bool, *protos.Task
 	if len(task.Name) > 30 {
 		task.Name = task.Name[:30]
 		log.Warnf("Job name exceeds 30 characters, trimmed to %v.\n", task.Name)
+	}
+	ofile := task.GetBatchMeta().OutputFilePattern
+	if i := strings.LastIndex(ofile, "/"); len(ofile) > i+FILE_MAX {
+		fname := ofile[i+1:]
+		trimmed := fname[len(fname)-FILE_MAX:]
+		task.GetBatchMeta().OutputFilePattern = trimmed
+		log.Warnf("Output file name exceeds %v characters, trimmed to %v.\n", FILE_MAX, trimmed)
+	}
+	efile := task.GetBatchMeta().ErrorFilePattern
+	if i := strings.LastIndex(efile, "/"); len(efile) > i+FILE_MAX {
+		fname := efile[i+1:]
+		trimmed := fname[len(fname)-FILE_MAX:]
+		task.GetBatchMeta().ErrorFilePattern = trimmed
+		log.Warnf("Error file name exceeds %v characters, trimmed to %v.\n", FILE_MAX, trimmed)
 	}
 
 	task.Resources.AllocatableResource.CpuCoreLimit = task.CpusPerTask * float64(task.NtasksPerNode)

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -261,14 +261,14 @@ func ProcessCbatchArgs(cmd *cobra.Command, args []CbatchArg) (bool, *protos.Task
 	ofile := task.GetBatchMeta().OutputFilePattern
 	if i := strings.LastIndex(ofile, "/"); len(ofile) > i+FILE_MAX {
 		fname := ofile[i+1:]
-		trimmed := fname[len(fname)-FILE_MAX:]
+		trimmed := ofile[:i+1] + fname[len(fname)-FILE_MAX:]
 		task.GetBatchMeta().OutputFilePattern = trimmed
 		log.Warnf("Output file name exceeds %v characters, trimmed to %v.\n", FILE_MAX, trimmed)
 	}
 	efile := task.GetBatchMeta().ErrorFilePattern
 	if i := strings.LastIndex(efile, "/"); len(efile) > i+FILE_MAX {
 		fname := efile[i+1:]
-		trimmed := fname[len(fname)-FILE_MAX:]
+		trimmed := efile[:i+1] + fname[len(fname)-FILE_MAX:]
 		task.GetBatchMeta().ErrorFilePattern = trimmed
 		log.Warnf("Error file name exceeds %v characters, trimmed to %v.\n", FILE_MAX, trimmed)
 	}


### PR DESCRIPTION
对于 cbatch 的 `OutputFilePattern` 与 `ErrorFilePattern`，若文件名长度超过 255（Linux 所允许的最大长度），则从左侧截短文件名。

`logs/overlong---Crane.log` -> `logs/Crane.log`