### PR TITLE
Feat: adapt table format

### DIFF
--- a/internal/cwrapper/lsf.go
+++ b/internal/cwrapper/lsf.go
@@ -209,6 +209,12 @@ func bjobs() *cobra.Command {
 		Args:    cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cqueue.FlagFilterJobIDs = strings.Join(args, ",")
+			if !cqueue.FlagNoHeader {
+				fmt.Printf("%s %s %s %s %s %s %s %s\n",
+					"JOBID", "USER", "STAT", "QUEUE", "FROM_HOST", "EXEC_HOST", "JOB_NAME", "SUBMIT_TIME")
+				cqueue.FlagNoHeader = true
+			}
+			cqueue.FlagFormat = "%j %u %t %P %L %L %n %s"
 			cqueue.RootCmd.Run(cmd, []string{})
 		},
 	}

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -28,6 +28,7 @@ import (
 	"CraneFrontEnd/internal/crun"
 	"CraneFrontEnd/internal/util"
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"slices"
@@ -388,10 +389,10 @@ func sacctmgr() *cobra.Command {
 
 func salloc() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "salloc",
-		Short:   "Wrapper of calloc command",
-		Long:    "",
-		GroupID: "slurm",
+		Use:                "salloc",
+		Short:              "Wrapper of calloc command",
+		Long:               "",
+		GroupID:            "slurm",
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Add --help from calloc
@@ -655,7 +656,12 @@ func squeue() *cobra.Command {
 				log.Error(err)
 				os.Exit(util.ErrorCmdArg)
 			}
-
+			if !cqueue.FlagNoHeader {
+				fmt.Printf("%s %s %s %s %s %s %s %s\n",
+					"JOBID", "PARTITION", "NAME", "USER", "ST", "TIME", "NODES", "NODELIST(REASON)")
+				cqueue.FlagNoHeader = true
+			}
+			cqueue.FlagFormat = "%j %P %n %u %t %e %N %r"
 			cqueue.RootCmd.Run(cmd, args)
 		},
 	}


### PR DESCRIPTION
修改 wrapper 中检索作业信息的命令，使其输出的表格字段相近于原始命令

## Known Issues
- 受程序结构限制，表头无法自适应宽度
- LSF 命令 `bjobs` 中有字段 `FROM_HOST`，表示提交作业的节点，目前并没有对等字段，其值与 `EXEC_HOST` 即作业运行的节点相同