### PR TITLE
fix crun/calloc job name length

### DIFF
--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -439,6 +439,7 @@ func MainCalloc(cmd *cobra.Command, args []string) util.CraneCmdError {
 	if FlagExport != "" {
 		task.Env["CRANE_EXPORT_ENV"] = FlagExport
 	}
+
 	// Check the validity of the parameters
 	if len(task.Name) > util.MaxJobNameLength {
 		log.Errorf("Job name exceeds %v characters.", util.MaxJobNameLength)

--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -439,6 +439,11 @@ func MainCalloc(cmd *cobra.Command, args []string) util.CraneCmdError {
 	if FlagExport != "" {
 		task.Env["CRANE_EXPORT_ENV"] = FlagExport
 	}
+	// Check the validity of the parameters
+	if len(task.Name) > util.MaxJobNameLength {
+		log.Errorf("Job name exceeds %v characters.", util.MaxJobNameLength)
+		return util.ErrorCmdArg
+	}
 	if err := util.CheckTaskArgs(task); err != nil {
 		log.Errorln(err)
 		return util.ErrorCmdArg

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -631,6 +631,12 @@ func MainCrun(cmd *cobra.Command, args []string) util.CraneCmdError {
 		task.Env["CRANE_EXPORT_ENV"] = FlagExport
 	}
 
+	// Check the validity of the parameters
+	if len(task.Name) > util.MaxJobNameLength {
+		log.Errorf("Job name exceeds %v characters.", util.MaxJobNameLength)
+		return util.ErrorCmdArg
+	}
+
 	if err := util.CheckTaskArgs(task); err != nil {
 		log.Errorln(err)
 		return util.ErrorCmdArg


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c04fe50c-5e8c-4206-9085-314f063402b1)
![image](https://github.com/user-attachments/assets/f4aeb1ca-aec4-45d7-a777-f84fa94598c2)
