### PR TITLE
feat: Add DefaultMemPerCPU and MaxMemPerCPU in ccontrol

### DIFF
--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -228,6 +228,7 @@ func ShowPartitions(partitionName string, queryAll bool) util.CraneCmdError {
 				"\tTotalCPU=%.2f AvailCPU=%.2f AllocCPU=%.2f\n"+
 				"\tTotalMem=%s AvailMem=%s AllocMem=%s\n"+
 				"\tTotalGres=%s AvailGres=%s AllocGres=%s\n"+
+				"\tDefaultMemPerCPU=%s MaxMemPerCPU=%s\n"+
 				"\tHostList=%v\n\n",
 				partitionInfo.Name, partitionInfo.State.String()[10:],
 				formatAllowedAccounts(partitionInfo.AllowedAccounts),
@@ -242,6 +243,8 @@ func ShowPartitions(partitionName string, queryAll bool) util.CraneCmdError {
 				formatDeviceMap(partitionInfo.ResTotal.GetDeviceMap()),
 				formatDeviceMap(partitionInfo.ResAvail.GetDeviceMap()),
 				formatDeviceMap(partitionInfo.ResAlloc.GetDeviceMap()),
+				formatMemToMB(partitionInfo.DefaultMemPerCpu),
+				formatMemToMB(partitionInfo.MaxMemPerCpu),
 				partitionInfo.Hostlist)
 		}
 	}

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -302,6 +302,9 @@ message PartitionInfo {
 
   repeated string allowed_accounts = 9;
   repeated string denied_accounts = 10;
+    
+  uint64 default_mem_per_cpu = 11;
+  uint64 max_mem_per_cpu = 12;
 }
 
 message CranedInfo {


### PR DESCRIPTION
ccontrol show partition增加DefaultMemPerCPU和MaxMemPerCPU这两个参数的输出

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Display now includes "Default Memory Per CPU" and "Max Memory Per CPU" information for partitions.
- **Documentation**
	- Updated partition information definitions to include new memory-related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->