### PR TITLE
feat: Add crun show name and cqueue show command

### DIFF
--- a/internal/cqueue/CmdArgParser.go
+++ b/internal/cqueue/CmdArgParser.go
@@ -125,6 +125,7 @@ Supported format identifiers or string, string case insensitive:
 	%m/%MemPerNode   - Display the requested mem per node of the job.
 	%N/%NodeNum      - Display the number of nodes requested by the job.
 	%n/%Name         - Display the name of the job.
+	%o/%Command      - Display the cmd of the job.
 	%P/%Partition    - Display the partition the job is running in.
 	%p/%Priority     - Display the priority of the job.
 	%q/%QoS          - Display the Quality of Service level for the job.

--- a/internal/cqueue/CmdArgParser.go
+++ b/internal/cqueue/CmdArgParser.go
@@ -125,7 +125,7 @@ Supported format identifiers or string, string case insensitive:
 	%m/%MemPerNode   - Display the requested mem per node of the job.
 	%N/%NodeNum      - Display the number of nodes requested by the job.
 	%n/%Name         - Display the name of the job.
-	%o/%Command      - Display the cmd of the job.
+	%o/%Command      - Display the command line of the job.
 	%P/%Partition    - Display the partition the job is running in.
 	%p/%Priority     - Display the priority of the job.
 	%q/%QoS          - Display the Quality of Service level for the job.

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -357,6 +357,11 @@ func ProcessNodeNum(task *protos.TaskInfo) string {
 }
 
 // 'p' group
+func ProcessCommand(task *protos.TaskInfo) string {
+	return task.CmdLine
+}
+
+// 'p' group
 func ProcessPriority(task *protos.TaskInfo) string {
 	return strconv.FormatUint(uint64(task.Priority), 10)
 }
@@ -470,6 +475,8 @@ var fieldMap = map[string]FieldProcessor{
 	"N":       {"NodeNum", ProcessNodeNum},
 	"nodenum": {"NodeNum", ProcessNodeNum},
 
+	"o":        {"Command", ProcessCommand},
+	"command":  {"Command", ProcessCommand},
 	// 'p' group
 	"p":         {"Priority", ProcessPriority},
 	"priority":  {"Priority", ProcessPriority},

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -356,7 +356,7 @@ func ProcessNodeNum(task *protos.TaskInfo) string {
 	return strconv.FormatUint(uint64(task.NodeNum), 10)
 }
 
-// 'p' group
+// 'o' group
 func ProcessCommand(task *protos.TaskInfo) string {
 	return task.CmdLine
 }
@@ -574,13 +574,13 @@ func FormatData(reply *protos.QueryTasksInfoReply) (header []string, tableData [
 		}
 
 		// a-Account, c-CpuPerNode, C-AllocCPUs, e-ElapsedTime, h-Held, j-JobID, k-Comment, l-TimeLimit, L-NodeList,
-		// m-MemPerNode, n-Name, N-NodeNum, p-Priority, P-Partition, q-Qos, R-Reason, r-ReqNodes, s-SubmitTime,
+		// m-MemPerNode, n-Name, N-NodeNum, o/Command, p-Priority, P-Partition, q-Qos, R-Reason, r-ReqNodes, s-SubmitTime,
 		// S-StartTime, t-State, T-JobType, u-User, U-Uid, x-ExcludeNodes
 		fieldProcessor, found := fieldMap[field]
 		if !found {
 			log.Errorf("Invalid format specifier or string : %s, string unfold case insensitive, reference:\n"+
 				"a/Account, c/CpuPerNode, C/AllocCPUs, e/ElapsedTime, h/Held, j/JobID, l/TimeLimit, k/Comment, L/NodeList,\n"+
-				"m/MemPerNode, n/Name, N/NodeNum, p/Priority, P/Partition, q/Qos, R/Reason, r/ReqNodes, s/SubmitTime,\n"+
+				"m/MemPerNode, n/Name, N/NodeNum, o/Command, p/Priority, P/Partition, q/Qos, R/Reason, r/ReqNodes, s/SubmitTime,\n"+
 				"S/StartTime, t/State, T/JobType, u/User, U/Uid, x/ExcludeNodes.", field)
 			os.Exit(util.ErrorInvalidFormat)
 		}

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -475,8 +475,8 @@ var fieldMap = map[string]FieldProcessor{
 	"N":       {"NodeNum", ProcessNodeNum},
 	"nodenum": {"NodeNum", ProcessNodeNum},
 
-	"o":        {"Command", ProcessCommand},
-	"command":  {"Command", ProcessCommand},
+	"o":       {"Command", ProcessCommand},
+	"command": {"Command", ProcessCommand},
 	// 'p' group
 	"p":         {"Priority", ProcessPriority},
 	"priority":  {"Priority", ProcessPriority},

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -829,6 +829,7 @@ func MainCrun(args []string) util.CraneCmdError {
 	task.NodeNum = FlagNodes
 	task.CpusPerTask = FlagCpuPerTask
 	task.NtasksPerNode = FlagNtasksPerNode
+	task.Name = util.ExtractExecNameFromArgs(args)
 
 	if FlagTime != "" {
 		seconds, err := util.ParseDurationStrToSeconds(FlagTime)

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -937,13 +937,12 @@ func ConvertSliceToString[T any](slice []T, sep string) string {
 	return strings.Join(str, sep)
 }
 
-
 func ExtractExecNameFromArgs(args []string) string {
-    for _, arg := range args {
-        name := path.Base(arg)
-        if name != "" {
-            return name
-        }
-    }
-    return "Interactive"
+	for _, arg := range args {
+		name := path.Base(arg)
+		if name != "" {
+			return name
+		}
+	}
+	return "Interactive"
 }

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -936,3 +936,14 @@ func ConvertSliceToString[T any](slice []T, sep string) string {
 	}
 	return strings.Join(str, sep)
 }
+
+
+func ExtractExecNameFromArgs(args []string) string {
+    for _, arg := range args {
+        name := path.Base(arg)
+        if name != "" {
+            return name
+        }
+    }
+    return "Interactive"
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/32548355-5408-485a-b93b-e03be6a766c4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to display the command line associated with a task.
	- Task names are now automatically set based on the executable name from command-line arguments when launching tasks.
	- Introduced a new format specifier to display task commands in output formatting options.
- **Bug Fixes**
	- Improved handling of cases where a task name cannot be derived, defaulting to "Interactive".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->