### PR TITLE
fix: Set keepalive for grpc server and client.

### DIFF
--- a/internal/cfored/server.go
+++ b/internal/cfored/server.go
@@ -433,8 +433,11 @@ func startGrpcServer(config *util.Config, wgAllRoutines *sync.WaitGroup) {
 
 	log.Tracef("Listening on unix socket %s", config.CranedCforedSockPath)
 
-	var opts []grpc.ServerOption
-	grpcServer := grpc.NewServer(opts...)
+	serverOptions := []grpc.ServerOption{
+		grpc.KeepaliveParams(util.ServerKeepAliveParams),
+		grpc.KeepaliveEnforcementPolicy(util.ServerKeepAlivePolicy),
+	}
+	grpcServer := grpc.NewServer(serverOptions...)
 
 	cforedServer := GrpcCforedServer{}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved connection stability and reliability for both gRPC server and client through enhanced keepalive settings and connection management.
- **Chores**
  - Updated internal configuration to apply explicit keepalive and connection parameters for gRPC communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->