### PR TITLE
cacctmgr show user delete useless line

### DIFF
--- a/internal/cacctmgr/cacctmgr.go
+++ b/internal/cacctmgr/cacctmgr.go
@@ -103,8 +103,7 @@ func PrintUserList(userList []*protos.UserInfo) {
 	util.SetBorderTable(table)
 	table.SetHeader([]string{"Account", "UserName", "Uid", "AllowedPartition", "AllowedQosList", "DefaultQos", "Coordinated", "AdminLevel", "Blocked"})
 	tableData := make([][]string, len(userMap))
-	for key, value := range userMap {
-		tableData = append(tableData, []string{key})
+	for _, value := range userMap {
 		for _, userInfo := range value {
 			if len(userInfo.AllowedPartitionQosList) == 0 {
 				tableData = append(tableData, []string{


### PR DESCRIPTION
改前：
![image](https://github.com/user-attachments/assets/bdd6ed89-1f19-4c83-8015-65351784080e)
改后
![image](https://github.com/user-attachments/assets/7471c6a3-0185-46af-b871-7c1336a6760d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of user lists by removing unnecessary rows containing only user keys. Now, only relevant user information is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->