### PR TITLE
Add cbatch gpus-per-node

### DIFF
--- a/internal/calloc/cmd.go
+++ b/internal/calloc/cmd.go
@@ -42,6 +42,7 @@ var (
 	FlagExport        string
 	FlagExclusive     bool
 	FlagWckey         string
+	FlagGpusPerNode   string
 
 	FlagExtraAttr string
 	FlagMailType  string
@@ -112,4 +113,5 @@ func init() {
 	RootCmd.Flags().BoolVarP(&FlagHold, "hold", "H", false, "Hold the job until it is released")
 	RootCmd.Flags().StringVarP(&FlagLicenses, "licenses", "L", "", "Licenses used for the job")
 	RootCmd.Flags().StringVar(&FlagWckey, "wckey", "", "Wckey of the job")
+	RootCmd.Flags().StringVar(&FlagGpusPerNode, "gpus-per-node", "", "Gpus required per node, format: [type:]<number>[,[type:]<number>...]. eg: \"4\" or \"a100:1,volta:1\"")
 }

--- a/internal/cbatch/cmd.go
+++ b/internal/cbatch/cmd.go
@@ -51,6 +51,7 @@ var (
 	FlagOpenMode      string
 	FlagExclusive     bool
 	FlagWckey         string
+	FlagGpusPerNode   string
 
 	FlagInterpreter   string
 	FlagWrappedScript string
@@ -73,7 +74,6 @@ var (
 	FlagArray           string
 	FlagNoRequeue       string
 	FlagParsable        string
-	FlagGpusPerNode     string
 	FlagNTasksPerSocket string
 	FlagSignal          string
 	FlagCpuFreq         string
@@ -177,4 +177,5 @@ func init() {
 	RootCmd.Flags().BoolVar(&FlagExclusive, "exclusive", false, "Exclusive node resources")
 	RootCmd.Flags().BoolVarP(&FlagHold, "hold", "H", false, "Hold the job until it is released")
 	RootCmd.Flags().StringVarP(&FlagBeginTime, "begin", "b", "", "Defer job until specified time.")
+	RootCmd.Flags().StringVar(&FlagGpusPerNode, "gpus-per-node", "", "Gpus required per node, format: [type:]<number>[,[type:]<number>...]. eg: \"4\" or \"a100:1,volta:1\"")
 }

--- a/internal/crun/cmd.go
+++ b/internal/crun/cmd.go
@@ -44,10 +44,11 @@ var (
 	FlagExport             string
 	FlagGres               string
 
-	FlagInput     string
-	FlagPty       bool
-	FlagExclusive bool
-	FlagWckey     string
+	FlagInput       string
+	FlagPty         bool
+	FlagExclusive   bool
+	FlagWckey       string
+	FlagGpusPerNode string
 
 	FlagX11    bool
 	FlagX11Fwd bool
@@ -137,4 +138,5 @@ func init() {
 	RootCmd.Flags().BoolVarP(&FlagHold, "hold", "H", false, "Hold the job until it is released")
 	RootCmd.Flags().StringVarP(&FlagLicenses, "licenses", "L", "", "Licenses used for the job")
 	RootCmd.Flags().StringVar(&FlagWckey, "wckey", "", "Wckey of the job")
+	RootCmd.Flags().StringVar(&FlagGpusPerNode, "gpus-per-node", "", "Gpus required per node, format: [type:]<number>[,[type:]<number>...]. eg: \"4\" or \"a100:1,volta:1\"")
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -89,6 +89,7 @@ const (
 	DefaultCforedServerListenPort    = "10012"
 
 	DefaultWrappedJobName          = "Wrap"
+	GresGpuName                    = "gpu"
 	MaxRepliedJobs                 = 1000 // See kDefaultQueryTaskNumLimit for details
 	MaxJobNameLength               = 60
 	MaxJobFileNameLength           = 127


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/614b3a42-7b3a-4f79-b75a-80c15be4d390)
![image](https://github.com/user-attachments/assets/4f478f67-643c-4dd1-9450-32afb7e565da)
![image](https://github.com/user-attachments/assets/10e57ae7-7d74-42de-81a5-7a47dbf2980f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --gpus-per-node flag to alloc, batch, and run commands to specify GPUs per node (single number or comma-separated type:count); applies to per-task GPU requirements.

* **Bug Fixes**
  * Enforced mutual exclusivity between --gres (GPU) and --gpus-per-node across all input sources.
  * Improved validation and clearer error messages for malformed --gpus-per-node inputs (empty parts, mixed formats, invalid counts).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->