### PR TITLE
fix: check CraneCtldForInternalListenPort in config

### DIFF
--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -65,6 +65,11 @@ func ParseConfig(configFilePath string) *Config {
 		config.CranedCforedSockPath = filepath.Join(config.CraneBaseDir, config.CranedCforedSockPath)
 	}
 
+	if config.CraneCtldForInternalListenPort == "" {
+		log.Errorf("CraneCtldForInternalListenPort is not set in config file %s", configFilePath)
+		os.Exit(ErrorGeneric)
+	}
+
 	return config
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation to ensure required configuration fields are set, with clear error messaging and immediate program exit if missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->