### PR TITLE
Revert "feat: Add job env (#270)"

### DIFF
--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -301,13 +301,6 @@ func ProcessCbatchArgs(cmd *cobra.Command, args []CbatchArg) (bool, *protos.Task
 	// Set total limit of cpu cores
 	task.ReqResources.AllocatableRes.CpuCoreLimit = task.CpusPerTask * float64(task.NtasksPerNode)
 
-	submitHostname, err := os.Hostname()
-	if err != nil {
-		log.Errorf("Failed to get hostname of the submitting host: %v", err)
-		return false, nil
-	}
-	task.SubmitHostname = submitHostname
-
 	// Check the validity of the parameters
 	if err := util.CheckFileLength(task.GetBatchMeta().OutputFilePattern); err != nil {
 		log.Errorf("Invalid argument: invalid output file path: %v", err)

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -168,7 +168,6 @@ message TaskToCtld {
   bool exclusive = 37;
 
   bool hold = 38;
-  string submit_hostname = 39;
 }
 
 message TaskInEmbeddedDb {
@@ -243,8 +242,7 @@ message TaskToD {
 
   bool get_user_env = 24;
   string container = 25;
-  string submit_hostname = 26;
-  uint32 total_gpus = 27;
+
   // Not used now.
   string extra_attr = 29;
 }

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -59,7 +59,6 @@ message InitSupervisorRequest {
   map<string, string> env = 10;
 
   string log_dir = 11;
-  string crane_cluster_name = 12;
 }
 
 message SupervisorReady {


### PR DESCRIPTION
This reverts commit ca801d1cce58601d3a476d870b71202756699da8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed collection and transmission of the submitting host's name in task messages.
  * Removed reporting of total GPU count in task messages.
  * Removed cluster name field from supervisor initialization requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->