### PR TITLE
fix: crun input

### DIFF
--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -965,7 +965,7 @@ func (m *StateMachineOfCrun) StartIOForward() {
 	m.chanX11OutputFromRemote = make(chan []byte, 20)
 
 	go m.forwardingSigHandlerRoutine()
-	if strings.ToLower(FlagInput) == "all" {
+	if strings.ToLower(FlagInput) == FlagInputALL {
 		go m.StdinReaderRoutine()
 	} else {
 		num, err := strconv.Atoi(FlagInput)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incompatible use of --pty with --input values other than "all" by returning a clear, actionable error.
  * Standardizes case-insensitive handling of --input=all to reliably control stdin forwarding behavior.
  * Improves reliability of interactive sessions by enforcing valid input configuration and avoiding unintended stdin forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->