### PR TITLE
feat: Add calloc/crun -Q/--quiet

### DIFF
--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -175,8 +175,9 @@ CallocStateMachineLoop:
 			if payload.Ok {
 				jobId = payload.JobId
 				stepId = payload.StepId
-				fmt.Printf("Task id allocated: %d\n", jobId)
-
+				if !FlagQuiet {
+					fmt.Printf("Task id allocated: %d\n", jobId)
+				}
 				state = WaitRes
 			} else {
 				_, _ = fmt.Fprintf(os.Stderr, "Failed to allocate task id: %s.\n", payload.FailureReason)
@@ -205,7 +206,9 @@ CallocStateMachineLoop:
 				Ok := cforedPayload.Ok
 
 				if Ok {
-					fmt.Printf("Allocated craned nodes: %s.\n", cforedPayload.AllocatedCranedRegex)
+					if !FlagQuiet {
+						fmt.Printf("Allocated craned nodes: %s.\n", cforedPayload.AllocatedCranedRegex)
+					}
 					state = TaskRunning
 				} else {
 					fmt.Println("Failed to allocate job resource. Exiting...")

--- a/internal/calloc/cmd.go
+++ b/internal/calloc/cmd.go
@@ -55,14 +55,14 @@ var (
 
 	FlagReservation string
 
-	FlagHold bool
+	FlagHold  bool
+	FlagQuiet bool
 
 	FlagLicenses string
 	// not implement feature:
 	FlagNTasks     string
 	FlagDependency string
 	FlagNoKill     string
-	FlagQuiet      string
 	FlagVerbose    string
 
 	RootCmd = &cobra.Command{
@@ -116,4 +116,5 @@ func init() {
 	RootCmd.Flags().StringVar(&FlagGpusPerNode, "gpus-per-node", "", "Gpus required per node, format: [type:]<number>[,[type:]<number>...]. eg: \"4\" or \"a100:1,volta:1\"")
 	RootCmd.Flags().StringVarP(&FlagMemPerCpu, "mem-per-cpu", "", "", "Maximum amount of real memory per CPU, support GB(G, g), MB(M, m), KB(K, k) and Bytes(B), default unit is MB")
 	RootCmd.MarkFlagsMutuallyExclusive("mem", "mem-per-cpu")
+	RootCmd.Flags().BoolVarP(&FlagQuiet, "quiet", "Q", false, "Quiet mode (suppress informational messages)")
 }

--- a/internal/crun/cmd.go
+++ b/internal/crun/cmd.go
@@ -64,7 +64,8 @@ var (
 
 	FlagReservation string
 
-	FlagHold bool
+	FlagHold  bool
+	FlagQuiet bool
 
 	FlagLicenses string
 	// not implement feature:
@@ -142,4 +143,5 @@ func init() {
 	RootCmd.Flags().StringVar(&FlagGpusPerNode, "gpus-per-node", "", "Gpus required per node, format: [type:]<number>[,[type:]<number>...]. eg: \"4\" or \"a100:1,volta:1\"")
 	RootCmd.Flags().StringVarP(&FlagMemPerCpu, "mem-per-cpu", "", "", "Maximum amount of real memory per CPU, support GB(G, g), MB(M, m), KB(K, k) and Bytes(B), default unit is MB")
 	RootCmd.MarkFlagsMutuallyExclusive("mem", "mem-per-cpu")
+	RootCmd.Flags().BoolVarP(&FlagQuiet, "quiet", "Q", false, "Quiet mode (suppress informational messages)")
 }

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -271,10 +271,12 @@ func (m *StateMachineOfCrun) StateReqTaskId() {
 		if payload.Ok {
 			m.jobId = payload.JobId
 			m.stepId = payload.StepId
-			if m.step == nil {
-				fmt.Printf("Task id allocated: %d, waiting resources.\n", m.jobId)
-			} else {
-				fmt.Printf("Job %d step %d allocated, waiting resources.\n", m.jobId, m.stepId)
+			if !FlagQuiet {
+				if m.step == nil {
+					fmt.Printf("Task id allocated: %d, waiting resources.\n", m.jobId)
+				} else {
+					fmt.Printf("Job %d step %d allocated, waiting resources.\n", m.jobId, m.stepId)
+				}
 			}
 			m.state = WaitRes
 		} else {
@@ -318,9 +320,10 @@ func (m *StateMachineOfCrun) StateWaitRes() {
 			Ok := cforedPayload.Ok
 
 			if Ok {
-				fmt.Printf("Allocated craned nodes: %s\n", cforedPayload.AllocatedCranedRegex)
-
-				m.cranedId = cforedPayload.CranedIds
+				if !FlagQuiet {
+					fmt.Printf("Allocated craned nodes: %s\n", cforedPayload.AllocatedCranedRegex)
+					m.cranedId = cforedPayload.CranedIds
+				}
 				m.state = WaitForward
 			} else {
 				log.Errorln("Failed to allocate job resource. Exiting...")
@@ -366,7 +369,9 @@ func (m *StateMachineOfCrun) StateWaitForward() {
 			cforedPayload := cforedReply.GetPayloadTaskIoForwardReadyReply()
 			Ok := cforedPayload.Ok
 			if Ok {
-				fmt.Println("Task io forward ready, waiting input.")
+				if !FlagQuiet {
+					fmt.Println("Task io forward ready, waiting input.")
+				}
 				m.state = Forwarding
 				return
 			} else {

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -240,7 +240,6 @@ func salloc() *cobra.Command {
 	cmd.Flags().StringVarP(&calloc.FlagDependency, "dependency", "d", "", "")
 	cmd.Flags().StringVar(&calloc.FlagMemPerCpu, "mem-per-cpu", "", "")
 	cmd.Flags().StringVarP(&calloc.FlagNoKill, "no-kill", "k", "", "")
-	cmd.Flags().StringVarP(&calloc.FlagQuiet, "quiet", "Q", "", "")
 	cmd.Flags().StringVarP(&calloc.FlagVerbose, "verbose", "v", "", "")
 
 	return cmd
@@ -801,9 +800,6 @@ func PrintSallocIgnoreDummyArgsMessage() {
 	}
 	if calloc.FlagNoKill != "" {
 		fmt.Fprintln(os.Stderr, "The feature --no-kill/-k is not yet supported by Crane, the use is ignored.")
-	}
-	if calloc.FlagQuiet != "" {
-		fmt.Fprintln(os.Stderr, "The feature --quiet/-Q is not yet supported by Crane, the use is ignored.")
 	}
 	if calloc.FlagVerbose != "" {
 		fmt.Fprintln(os.Stderr, "The feature --verbose/-v is not yet supported by Crane, the use is ignored.")


### PR DESCRIPTION
<img width="828" height="207" alt="image" src="https://github.com/user-attachments/assets/3552515a-bf3e-4119-acd5-8bb37bccb06a" />
<img width="1220" height="262" alt="image" src="https://github.com/user-attachments/assets/0029eb38-9f81-4672-90bc-d2a5a34c72b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --quiet / -Q option to suppress informational console messages for calloc and crun; routine status updates are hidden when enabled, while errors and final outputs remain visible.  
* **Chores**
  * Removed the now-unsupported quiet binding and related informational message from the salloc wrapper.  
* **Notes**
  * Default behavior unchanged; no public command signatures altered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->