### PR TITLE
fix: Cacct exit code display

### DIFF
--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -386,8 +386,8 @@ func ProcessEndTime(task *protos.TaskInfo) string {
 // ExitCode (e)
 func ProcessExitCode(task *protos.TaskInfo) string {
 	exitCode := ""
-	if task.ExitCode >= kCraneExitCodeBase {
-		exitCode = fmt.Sprintf("0:%d", task.ExitCode-kCraneExitCodeBase)
+	if task.ExitCode >= kTerminationSignalBase {
+		exitCode = fmt.Sprintf("0:%d", task.ExitCode-kTerminationSignalBase)
 	} else {
 		exitCode = fmt.Sprintf("%d:0", task.ExitCode)
 	}

--- a/internal/cfored/crunServer.go
+++ b/internal/cfored/crunServer.go
@@ -230,7 +230,7 @@ CforedCrunStateMachineLoop:
 				} else {
 					// Crun task req failed
 					// channel was already removed from gVars.ctldReplyChannelMapByPid
-					log.Infof("[Cfored<->Crun][Step #%d.%d] Task request failed", taskId, stepId)
+					log.Infof("[Cfored<->Crun][Pid #%d] Task request failed", crunPid)
 					break CforedCrunStateMachineLoop
 				}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected process exit code reporting to accurately distinguish termination signals from regular exits.
  * Exit codes are now mapped consistently, improving clarity in job status and logs.
  * Users may see adjusted exit/termination codes in summaries and monitoring views, reflecting the corrected interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->