### PR TITLE
feat: auto nodes

### DIFF
--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -974,7 +974,7 @@ func CreateReservation() error {
 	} else {
 		if FlagPartitionName == "" {
 			return &util.CraneError{
-				Code: util.ErrorCmdArg,
+				Code:    util.ErrorCmdArg,
 				Message: "Partition name must be specified when no node regex is given.",
 			}
 		}

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -985,7 +985,7 @@ func CreateReservation() error {
 	}
 
 	if FlagNodeNum != 0 {
-		req.NodeNum = &FlagNodeNum
+		req.NodeNum = FlagNodeNum
 	}
 
 	if FlagAccount != "" {

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -995,6 +995,12 @@ func CreateReservation() error {
 				Message: "You can only specify either allowed or disallowed accounts.",
 			}
 		}
+		if len(req.AllowedAccounts) == 0 && len(req.DeniedAccounts) == 0 {
+			return &util.CraneError{
+				Code:    util.ErrorCmdArg,
+				Message: "Account can not be empty.",
+			}
+		}
 	}
 
 	if FlagUser != "" {

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -977,6 +977,10 @@ func CreateReservation() error {
 		req.Partition = FlagPartitionName
 	}
 
+	if FlagNodeNum != 0 {
+		req.NodeNum = &FlagNodeNum
+	}
+
 	if FlagAccount != "" {
 		req.AllowedAccounts, req.DeniedAccounts, err = util.ParsePosNegList(FlagAccount)
 		if err != nil {

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -971,6 +971,13 @@ func CreateReservation() error {
 
 	if FlagNodes != "" {
 		req.CranedRegex = FlagNodes
+	} else {
+		if FlagPartitionName == "" {
+			return &util.CraneError{
+				Code: util.ErrorCmdArg,
+				Message: "Partition name must be specified when no node regex is given.",
+			}
+		}
 	}
 
 	if FlagPartitionName != "" {

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -49,6 +49,7 @@ var (
 	FlagNodes           string
 	FlagAccount         string
 	FlagUser            string
+	FlagNodeNum         uint32
 )
 
 func ParseCmdArgs(args []string) {
@@ -444,7 +445,7 @@ func executeCreateReservationCommand(command *CControlCommand) int {
 
 	kvParams := command.GetKVMaps()
 
-	err := checkEmptyKVParams(kvParams, []string{"starttime", "duration", "account"})
+	err := checkEmptyKVParams(kvParams, []string{"starttime", "partition", "duration", "account"})
 	if err != util.ErrorSuccess {
 		return err
 	}
@@ -463,6 +464,13 @@ func executeCreateReservationCommand(command *CControlCommand) int {
 			FlagAccount = value
 		case "user":
 			FlagUser = value
+		case "nodecnt":
+			nodeNum, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				log.Errorf("invalid nodenum value: %s", value)
+				return util.ErrorCmdArg
+			}
+			FlagNodeNum = uint32(nodeNum)
 		default:
 			log.Errorf("unknown attribute to modify: %s", key)
 			return util.ErrorCmdArg

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -445,7 +445,7 @@ func executeCreateReservationCommand(command *CControlCommand) int {
 
 	kvParams := command.GetKVMaps()
 
-	err := checkEmptyKVParams(kvParams, []string{"starttime", "partition", "duration", "account"})
+	err := checkEmptyKVParams(kvParams, []string{"starttime", "duration", "account"})
 	if err != util.ErrorSuccess {
 		return err
 	}

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -95,6 +95,7 @@ COMMANDS:
     nodes: List of nodes to reserve
     account: Account to associate with the reservation
     user: User to associate with the reservation
+    nodeCnt: Number of nodes to reserve (valid when nodes is not specified)
 
   delete reservation <name>
     Delete an existing reservation.

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -496,6 +496,8 @@ message CreateReservationRequest {
   repeated string denied_accounts = 8;
   repeated string allowed_users = 9;
   repeated string denied_users = 10;
+
+  optional uint32 node_num = 11;
 }
 
 message CreateReservationReply {

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -497,7 +497,7 @@ message CreateReservationRequest {
   repeated string allowed_users = 9;
   repeated string denied_users = 10;
 
-  optional uint32 node_num = 11;
+  uint32 node_num = 11;
 }
 
 message CreateReservationReply {


### PR DESCRIPTION
自动节点选择和批量报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify number of nodes when creating a reservation without node selectors; CLI and API accept a node-count parameter.
* **Bug Fixes**
  * Partition is now required when no node selector is provided.
  * Validation error when account settings are provided but contain no accounts.
* **Documentation**
  * Help text updated to include the new node-count option for reservation creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->