### PR TITLE
feat: Change TLS to use a single CA.

### DIFF
--- a/internal/util/grpc.go
+++ b/internal/util/grpc.go
@@ -119,7 +119,7 @@ func (c *UnixPeerCredentials) OverrideServerName(s string) error       { return 
 
 func GetTCPSocket(bindAddr string, config *Config) (net.Listener, error) {
 	if config.TlsConfig.Enabled {
-		CaCertContent, err := os.ReadFile(config.TlsConfig.InternalCaFilePath)
+		CaCertContent, err := os.ReadFile(config.TlsConfig.CaFilePath)
 		if err != nil {
 			return nil, err
 		}
@@ -278,7 +278,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 			os.Exit(ErrorGeneric)
 		}
 
-		CaCertContent, err := os.ReadFile(config.TlsConfig.InternalCaFilePath)
+		CaCertContent, err := os.ReadFile(config.TlsConfig.CaFilePath)
 		if err != nil {
 			log.Errorln("Read CA certifacate error: " + err.Error())
 			os.Exit(ErrorGeneric)
@@ -338,7 +338,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 func UpdateTLSConfig(config *Config) (*tls.Config, error) {
 
 	if err := SignAndSaveUserCertificate(config); err != nil {
-		caCert, err := os.ReadFile(config.TlsConfig.ExternalCaFilePath)
+		caCert, err := os.ReadFile(config.TlsConfig.CaFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/pki.go
+++ b/internal/util/pki.go
@@ -74,7 +74,7 @@ func DoSignAndSaveUserCertificate(config *Config) error {
 	serverAddr := fmt.Sprintf("%s.%s:%s",
 		config.ControlMachine, config.TlsConfig.DomainSuffix, config.CraneCtldListenPort)
 
-	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.ExternalCaFilePath, "*."+config.TlsConfig.DomainSuffix)
+	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, "*."+config.TlsConfig.DomainSuffix)
 	if err != nil {
 		return err
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -45,9 +45,8 @@ type TLSConfig struct {
 	Enabled              bool   `yaml:"Enabled"`
 	InternalCertFilePath string `yaml:"InternalCertFilePath"`
 	InternalKeyFilePath  string `yaml:"InternalKeyFilePath"`
-	InternalCaFilePath   string `yaml:"InternalCaFilePath"`
-	ExternalCaFilePath   string `yaml:"ExternalCaFilePath"`
 	ExternalCertFilePath string `yaml:"ExternalCertFilePath"`
+	CaFilePath           string `yaml:"CaFilePath"`
 	DomainSuffix         string `yaml:"DomainSuffix"`
 	UserTlsCertPath      string `yaml:"UserTlsCertPath"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified TLS configuration by replacing separate internal/external CA certificate path settings with a single CaFilePath.
  - Unified use of the new CA path across secure connections for consistent behavior.
  - No changes to public APIs; TLS enablement and error handling remain unchanged.
  - Action required: update configuration files to replace InternalCaFilePath/ExternalCaFilePath with CaFilePath.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->