### PR TITLE
feat: add TaskStatus Suspend

### DIFF
--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -356,6 +356,18 @@ func ProcessElapsedTime(item *JobOrStep) string {
 			return util.SecondTimeFormat(item.job.ElapsedTime.Seconds)
 		}
 	} else if status == protos.JobStatus_Completed {
+		// Prefer backend elapsed time (already excludes suspended duration).
+		if item.isStep {
+			if item.stepInfo.ElapsedTime != nil && item.stepInfo.ElapsedTime.Seconds > 0 {
+				return util.SecondTimeFormat(item.stepInfo.ElapsedTime.Seconds)
+			}
+		} else {
+			if item.job.ElapsedTime != nil && item.job.ElapsedTime.Seconds > 0 {
+				return util.SecondTimeFormat(item.job.ElapsedTime.Seconds)
+			}
+		}
+
+		// Fallback to derived duration if elapsed time is unavailable.
 		if startTime.IsZero() || endTime.IsZero() {
 			return "-"
 		}

--- a/internal/ccancel/cmd.go
+++ b/internal/ccancel/cmd.go
@@ -37,7 +37,7 @@ var (
 
 	RootCmd = &cobra.Command{
 		Use:     "ccancel [flags] JOBID.STEPID[,JOBID.STEPID...]",
-		Short:   "Cancel pending or running jobs/steps",
+		Short:   "Cancel pending, running or suspended jobs/steps",
 		Long:    "",
 		Version: util.Version(),
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -92,14 +92,14 @@ func init() {
 		"Cancel jobs in the specified partition")
 	RootCmd.Flags().StringVarP(&FlagState, "state", "t", "",
 		"Cancel jobs of the specified states"+
-			"Valid job states are PENDING(P), RUNNING(R), ALL. "+
+			"Valid job states are PENDING(P), RUNNING(R), SUSPENDED(S), ALL. "+
 			"job states are case-insensitive")
 	RootCmd.Flags().StringVarP(&FlagAccount, "account", "A", "",
 		"Cancel jobs under the specified account")
 	RootCmd.Flags().StringVarP(&FlagUserName, "user", "u", "",
 		"Cancel jobs submitted by the specified user")
 	RootCmd.Flags().StringSliceVarP(&FlagNodes, "nodes", "w", nil,
-		"Cancel jobs running on the specified nodes")
+		"Cancel jobs running or suspended on the specified nodes")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")
 	util.InitCraneLogger()

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -233,22 +233,7 @@ func HoldReleaseJobs(jobs string, hold bool) error {
 	return SummarizeReply(reply)
 }
 
-// isCgroupV2 checks whether the system uses cgroup v2 (unified hierarchy).
-// Returns true if cgroup v2 is detected, false otherwise (v1 or hybrid).
-func isCgroupV2() bool {
-	// In cgroup v2 (unified hierarchy), the file "cgroup.controllers"
-	// exists at the root of the cgroup filesystem.
-	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
-	return err == nil
-}
-
 func SuspendJobs(jobs string) error {
-	if !isCgroupV2() {
-		return util.NewCraneErr(util.ErrorGeneric,
-			"Suspend is not supported under cgroup v1. "+
-				"Please upgrade to cgroup v2 (unified hierarchy) to use suspend/resume.")
-	}
-
 	jobList, err := util.ParseJobIdList(jobs, ",")
 	if err != nil {
 		log.Errorf("invalid job list: %s", err)
@@ -276,12 +261,6 @@ func SuspendJobs(jobs string) error {
 }
 
 func ResumeJobs(jobs string) error {
-	if !isCgroupV2() {
-		return util.NewCraneErr(util.ErrorGeneric,
-			"Resume is not supported under cgroup v1. "+
-				"Please upgrade to cgroup v2 (unified hierarchy) to use suspend/resume.")
-	}
-
 	jobList, err := util.ParseJobIdList(jobs, ",")
 	if err != nil {
 		log.Errorf("invalid job list: %s", err)

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -233,6 +233,60 @@ func HoldReleaseJobs(jobs string, hold bool) error {
 	return SummarizeReply(reply)
 }
 
+func SuspendJobs(jobs string) error {
+	jobList, err := util.ParseJobIdList(jobs, ",")
+	if err != nil {
+		log.Errorf("invalid job list: %s", err)
+		return &util.CraneError{Code: util.ErrorCmdArg}
+	}
+
+	req := &protos.ModifyJobRequest{
+		Uid:       uint32(os.Getuid()),
+		JobIds:    jobList,
+		Attribute: protos.ModifyJobRequest_Suspend,
+	}
+
+	reply, err := stub.ModifyJob(context.Background(), req)
+	if err != nil {
+		util.GrpcErrorPrintf(err, "Failed to suspend jobs")
+		return &util.CraneError{Code: util.ErrorNetwork}
+	}
+
+	if FlagJson {
+		fmt.Println(util.FmtJson.FormatReply(reply))
+		return nil
+	}
+
+	return SummarizeReply(reply)
+}
+
+func ResumeJobs(jobs string) error {
+	jobList, err := util.ParseJobIdList(jobs, ",")
+	if err != nil {
+		log.Errorf("invalid job list: %s", err)
+		return &util.CraneError{Code: util.ErrorCmdArg}
+	}
+
+	req := &protos.ModifyJobRequest{
+		Uid:       uint32(os.Getuid()),
+		JobIds:    jobList,
+		Attribute: protos.ModifyJobRequest_Resume,
+	}
+
+	reply, err := stub.ModifyJob(context.Background(), req)
+	if err != nil {
+		util.GrpcErrorPrintf(err, "Failed to resume jobs")
+		return &util.CraneError{Code: util.ErrorNetwork}
+	}
+
+	if FlagJson {
+		fmt.Println(util.FmtJson.FormatReply(reply))
+		return nil
+	}
+
+	return SummarizeReply(reply)
+}
+
 func ChangeJobPriority(jobStr string, priority float64) error {
 	if priority < 0 {
 		return util.NewCraneErr(util.ErrorCmdArg, "Priority must be greater than or equal to 0.")

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -233,7 +233,22 @@ func HoldReleaseJobs(jobs string, hold bool) error {
 	return SummarizeReply(reply)
 }
 
+// isCgroupV2 checks whether the system uses cgroup v2 (unified hierarchy).
+// Returns true if cgroup v2 is detected, false otherwise (v1 or hybrid).
+func isCgroupV2() bool {
+	// In cgroup v2 (unified hierarchy), the file "cgroup.controllers"
+	// exists at the root of the cgroup filesystem.
+	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
+	return err == nil
+}
+
 func SuspendJobs(jobs string) error {
+	if !isCgroupV2() {
+		return util.NewCraneErr(util.ErrorGeneric,
+			"Suspend is not supported under cgroup v1. "+
+				"Please upgrade to cgroup v2 (unified hierarchy) to use suspend/resume.")
+	}
+
 	jobList, err := util.ParseJobIdList(jobs, ",")
 	if err != nil {
 		log.Errorf("invalid job list: %s", err)
@@ -261,6 +276,12 @@ func SuspendJobs(jobs string) error {
 }
 
 func ResumeJobs(jobs string) error {
+	if !isCgroupV2() {
+		return util.NewCraneErr(util.ErrorGeneric,
+			"Resume is not supported under cgroup v1. "+
+				"Please upgrade to cgroup v2 (unified hierarchy) to use suspend/resume.")
+	}
+
 	jobList, err := util.ParseJobIdList(jobs, ",")
 	if err != nil {
 		log.Errorf("invalid job list: %s", err)

--- a/internal/ccontrol/ccontrol.go
+++ b/internal/ccontrol/ccontrol.go
@@ -254,6 +254,10 @@ func SuspendJobs(jobs string) error {
 
 	if FlagJson {
 		fmt.Println(util.FmtJson.FormatReply(reply))
+		// Check if there are any failures and return appropriate error code
+		if len(reply.NotModifiedJobs) > 0 {
+			return &util.CraneError{Code: util.ErrorBackend}
+		}
 		return nil
 	}
 
@@ -281,6 +285,10 @@ func ResumeJobs(jobs string) error {
 
 	if FlagJson {
 		fmt.Println(util.FmtJson.FormatReply(reply))
+		// Check if there are any failures and return appropriate error code
+		if len(reply.NotModifiedJobs) > 0 {
+			return &util.CraneError{Code: util.ErrorBackend}
+		}
 		return nil
 	}
 

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -61,6 +61,8 @@ var actionToExecute = map[string]func(command *CControlCommand) error{
 	"update":  executeUpdateCommand,
 	"hold":    executeHoldCommand,
 	"release": executeReleaseCommand,
+	"suspend": executeSuspendCommand,
+	"resume":  executeResumeCommand,
 	"create":  executeCreateCommand,
 	"delete":  executeDeleteCommand,
 	"reset":   executeResetCommand,
@@ -406,6 +408,32 @@ func executeReleaseCommand(command *CControlCommand) error {
 	err := HoldReleaseJobs(jobIds, false)
 	if err != nil {
 		return util.WrapCraneErr(util.ErrorGeneric, "release jobs failed: %s\n", err)
+	}
+	return nil
+}
+
+func executeSuspendCommand(command *CControlCommand) error {
+	jobIds := command.GetID()
+	if jobIds == "" {
+		return util.NewCraneErr(util.ErrorCmdArg, fmt.Sprintln("no job id specified"))
+	}
+
+	err := SuspendJobs(jobIds)
+	if err != nil {
+		return util.WrapCraneErr(util.ErrorGeneric, "suspend jobs failed: %s\n", err)
+	}
+	return nil
+}
+
+func executeResumeCommand(command *CControlCommand) error {
+	jobIds := command.GetID()
+	if jobIds == "" {
+		return util.NewCraneErr(util.ErrorCmdArg, fmt.Sprintln("no job id specified"))
+	}
+
+	err := ResumeJobs(jobIds)
+	if err != nil {
+		return util.WrapCraneErr(util.ErrorGeneric, "resume jobs failed: %s\n", err)
 	}
 	return nil
 }

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -420,6 +420,10 @@ func executeSuspendCommand(command *CControlCommand) error {
 
 	err := SuspendJobs(jobIds)
 	if err != nil {
+		var craneErr *util.CraneError
+		if FlagJson && errors.As(err, &craneErr) && craneErr != nil && craneErr.Message == "" {
+			return craneErr
+		}
 		return util.WrapCraneErr(util.ErrorGeneric, "suspend jobs failed: %s\n", err)
 	}
 	return nil
@@ -433,6 +437,10 @@ func executeResumeCommand(command *CControlCommand) error {
 
 	err := ResumeJobs(jobIds)
 	if err != nil {
+		var craneErr *util.CraneError
+		if FlagJson && errors.As(err, &craneErr) && craneErr != nil && craneErr.Message == "" {
+			return craneErr
+		}
 		return util.WrapCraneErr(util.ErrorGeneric, "resume jobs failed: %s\n", err)
 	}
 	return nil

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -420,9 +420,8 @@ func executeSuspendCommand(command *CControlCommand) error {
 
 	err := SuspendJobs(jobIds)
 	if err != nil {
-		var craneErr *util.CraneError
-		if FlagJson && errors.As(err, &craneErr) && craneErr != nil && craneErr.Message == "" {
-			return craneErr
+		if FlagJson {
+			return err
 		}
 		return util.WrapCraneErr(util.ErrorGeneric, "suspend jobs failed: %s\n", err)
 	}
@@ -437,9 +436,8 @@ func executeResumeCommand(command *CControlCommand) error {
 
 	err := ResumeJobs(jobIds)
 	if err != nil {
-		var craneErr *util.CraneError
-		if FlagJson && errors.As(err, &craneErr) && craneErr != nil && craneErr.Message == "" {
-			return craneErr
+		if FlagJson {
+			return err
 		}
 		return util.WrapCraneErr(util.ErrorGeneric, "resume jobs failed: %s\n", err)
 	}

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -91,6 +91,12 @@ COMMANDS:
   release <jobid>
     Release a previously held job.
 
+  suspend <jobid>
+    Suspend specified running job(s) to free their allocated resources while keeping progress.
+
+  resume <jobid>
+    Resume previously suspended job(s).
+
   create reservation <name> [startTime=<time>] [duration=<duration>] [partition=<partition>]
                     [nodes=<nodelist>] [account=<account>] [user=<username>]
     Create a new reservation.

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -92,7 +92,7 @@ COMMANDS:
     Release a previously held job.
 
   suspend <jobid>
-    Suspend specified running job(s) to free their allocated resources while keeping progress.
+    Suspend specified running job(s) by freezing their processes while keeping allocated resources.
 
   resume <jobid>
     Resume previously suspended job(s).

--- a/internal/ccontrol/parser.go
+++ b/internal/ccontrol/parser.go
@@ -57,6 +57,18 @@ type ReleaseCommand struct {
 	KeyValueParam []*KeyValueParam `parser:"@@*"`
 }
 
+type SuspendCommand struct {
+	Action        string           `parser:"@'suspend'"`
+	ID            string           `parser:"( @String | @Ident | @Number )?"`
+	KeyValueParam []*KeyValueParam `parser:"@@*"`
+}
+
+type ResumeCommand struct {
+	Action        string           `parser:"@'resume'"`
+	ID            string           `parser:"( @String | @Ident | @Number )?"`
+	KeyValueParam []*KeyValueParam `parser:"@@*"`
+}
+
 type CreateCommand struct {
 	Action        string           `parser:"@'create'"`
 	Entity        *EntityType      `parser:"@@"`
@@ -106,7 +118,7 @@ var CControlLexer = lexer.MustSimple([]lexer.SimpleRule{
 var CControlParser = participle.MustBuild[CControlCommand](
 	participle.Lexer(CControlLexer),
 	participle.Elide("whitespace"),
-	participle.Union[any](ShowCommand{}, UpdateCommand{}, HoldCommand{}, ReleaseCommand{}, CreateCommand{}, DeleteCommand{}, ResetCommand{}),
+	participle.Union[any](ShowCommand{}, UpdateCommand{}, HoldCommand{}, ReleaseCommand{}, SuspendCommand{}, ResumeCommand{}, CreateCommand{}, DeleteCommand{}, ResetCommand{}),
 )
 
 func ParseCControlCommand(input string) (*CControlCommand, error) {
@@ -152,6 +164,10 @@ func (c *CControlCommand) GetAction() string {
 		return cmd.Action
 	case ReleaseCommand:
 		return cmd.Action
+	case SuspendCommand:
+		return cmd.Action
+	case ResumeCommand:
+		return cmd.Action
 	case ResetCommand:
 		return cmd.Action
 	case CreateCommand:
@@ -193,6 +209,10 @@ func (c *CControlCommand) GetID() string {
 		return cmd.ID
 	case ReleaseCommand:
 		return cmd.ID
+	case SuspendCommand:
+		return cmd.ID
+	case ResumeCommand:
+		return cmd.ID
 	case DeleteCommand:
 		return cmd.ID
 	case CreateCommand:
@@ -211,6 +231,10 @@ func (c *CControlCommand) GetKVParamValue(key string) string {
 	case HoldCommand:
 		params = cmd.KeyValueParam
 	case ReleaseCommand:
+		params = cmd.KeyValueParam
+	case SuspendCommand:
+		params = cmd.KeyValueParam
+	case ResumeCommand:
 		params = cmd.KeyValueParam
 	case CreateCommand:
 		params = cmd.KeyValueParam
@@ -236,6 +260,14 @@ func (c *CControlCommand) GetKVMaps() map[string]string {
 			kvMap[param.Key] = unquoteIfQuoted(param.Value)
 		}
 	case ReleaseCommand:
+		for _, param := range cmd.KeyValueParam {
+			kvMap[param.Key] = unquoteIfQuoted(param.Value)
+		}
+	case SuspendCommand:
+		for _, param := range cmd.KeyValueParam {
+			kvMap[param.Key] = unquoteIfQuoted(param.Value)
+		}
+	case ResumeCommand:
 		for _, param := range cmd.KeyValueParam {
 			kvMap[param.Key] = unquoteIfQuoted(param.Value)
 		}

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -1438,6 +1438,8 @@ func ParseJobStatusName(state string) (protos.JobStatus, error) {
 		return protos.JobStatus_Cancelled, nil
 	case "oom", "out-of-memory", "outofmemory", "o":
 		return protos.JobStatus_OutOfMemory, nil
+	case "suspended", "suspend", "s":
+		return protos.JobStatus_Suspended, nil
 	case "all":
 		return protos.JobStatus_Invalid, nil
 	default:

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -1507,7 +1507,8 @@ func ParseInRamJobStatusList(statesStr string) ([]protos.JobStatus, error) {
 		if err != nil {
 			return nil, err
 		}
-		if state != protos.JobStatus_Invalid && state != protos.JobStatus_Pending && state != protos.JobStatus_Running {
+		if state != protos.JobStatus_Invalid && state != protos.JobStatus_Pending &&
+			state != protos.JobStatus_Running && state != protos.JobStatus_Suspended {
 			return nil, fmt.Errorf("unsupported state: %s", filterStateList[i])
 		}
 		stateSet[state] = true

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -260,6 +260,8 @@ message ModifyJobRequest {
     Priority = 1;
     Hold = 2;
     Deadline = 3;
+    Suspend = 4;
+    Resume = 5;
   }
 
   uint32 uid = 1;

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -117,6 +117,7 @@ enum JobStatus {
   Configuring = 7;
   Starting = 8;
   Completing = 9;
+  Suspended = 10;
 
   Deadline = 10;
   Invalid = 15;

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -118,8 +118,8 @@ enum JobStatus {
   Starting = 8;
   Completing = 9;
   Suspended = 10;
+  Deadline = 11;
 
-  Deadline = 10;
   Invalid = 15;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added job suspension and resumption: pause running jobs to free resources and resume later.
  - New CLI commands: suspend <jobid> and resume <jobid>.
  - Task status now includes “Suspended” (aliases: suspended, suspend, s).
  - CLI can return formatted JSON for suspend/resume responses.
  - Suspend/resume may be unavailable on some systems; commands will report if unsupported.

- Documentation
  - Help output updated with usage and descriptions for suspend and resume commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->