### PR TITLE
fix: max-line cmd help

### DIFF
--- a/internal/cacct/cmd.go
+++ b/internal/cacct/cmd.go
@@ -157,7 +157,7 @@ Examples:
 Note: If the format is invalid or unrecognized, the program will terminate with an error message.
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false, "Display full information (If not set, only display 30 characters per cell)")
-	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 0,
-		"Limit the number of lines in the output, default is 0 (no limit)")
+	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.MaxRepliedJobs,
+		"Limit the number of lines in the output, 0 means no limit") // See kDefaultQueryTaskNumLimit
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false, "Output in JSON format")
 }

--- a/internal/cqueue/cmd.go
+++ b/internal/cqueue/cmd.go
@@ -147,8 +147,8 @@ Note: If the format is invalid or unrecognized, the program will terminate with 
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false,
 		"Display full information (If not set, only display 30 characters per cell)")
-	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 0,
-		"Limit the number of lines in the output, default is 0 (no limit)")
+	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.MaxRepliedJobs,
+		"Limit the number of lines in the output, 0 means no limit")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")
 }

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -66,11 +66,8 @@ func QueryTasksInfo() (*protos.QueryTasksInfoReply, error) {
 	if err != nil {
 		return &protos.QueryTasksInfoReply{}, err
 	}
-	// Use a 10-second timeout for the RPC
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	reply, err := stub.QueryTasksInfo(ctx, req)
+	reply, err := stub.QueryTasksInfo(context.Background(), req)
 	if err != nil {
 		util.GrpcErrorPrintf(err, "Failed to query task queue")
 		return nil, &util.CraneError{Code: util.ErrorNetwork}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -88,6 +88,7 @@ const (
 	DefaultCforedServerListenPort    = "10012"
 
 	DefaultWrappedJobName          = "Wrap"
+	MaxRepliedJobs                 = 1000 // See kDefaultQueryTaskNumLimit for details
 	MaxJobNameLength               = 60
 	MaxJobFileNameLength           = 127
 	MaxJobFilePathLengthForWindows = 260 - MaxJobFileNameLength


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified default output line limit configuration to apply consistently across commands
  * Removed timeout restriction on query operations

* **Documentation**
  * Updated help text to clarify line limit behavior and default constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->