### PR TITLE
feat: Add --config to cwrapper subcommands

### DIFF
--- a/internal/cwrapper/cmd.go
+++ b/internal/cwrapper/cmd.go
@@ -61,3 +61,7 @@ func ParseCmdArgs() {
 
 	util.RunAndHandleExit(rootCmd)
 }
+
+func addConfigPathFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVar(target, "config", util.DefaultConfigPath, "Path to configuration file")
+}

--- a/internal/cwrapper/lsf.go
+++ b/internal/cwrapper/lsf.go
@@ -130,6 +130,7 @@ func bacct() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cacct.FlagConfigFilePath)
 	cmd.Flags().StringVar(&cacct.FlagFilterUsers, "u", "", "Displays accounting statistics for jobs that are submitted by the specified users")
 	cmd.Flags().StringVar(&cacct.FlagFilterStartTime, "D", "", "Displays accounting statistics for jobs that are dispatched during the specified time interval")
 	cmd.Flags().StringVar(&cacct.FlagFilterEndTime, "C", "", "Displays accounting statistics for jobs that completed or exited during the specified time interval")
@@ -182,6 +183,7 @@ func bsub() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cbatch.FlagConfigFilePath)
 	cmd.Flags().StringVar(&cbatch.FlagJob, "J", "", "Assigns the specified name to the job")
 	cmd.Flags().StringVar(&cbatch.FlagStdoutPath, "o", "", "Appends the standard output of the job to the specified file path")
 	cmd.Flags().StringVar(&cbatch.FlagStderrPath, "e", "", "Appends the standard error output of the job to the specified file path")
@@ -223,6 +225,7 @@ func bjobs() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cqueue.FlagConfigFilePath)
 	cmd.Flags().StringVar(&cqueue.FlagFilterJobNames, "J", "", "Displays information about jobs with the specified job name")
 	cmd.Flags().BoolVar(&cqueue.FlagNoHeader, "noheader", false, "Removes the column headings from the output")
 
@@ -245,6 +248,7 @@ func bqueues() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	cmd.Flags().StringSliceVar(&cinfo.FlagFilterNodes, "m", nil, "Displays the queues that can run jobs on the specified host")
 
 	return cmd
@@ -289,6 +293,7 @@ func bkill() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &ccancel.FlagConfigFilePath)
 	cmd.Flags().StringVar(&ccancel.FlagJobName, "J", "", "Operates only on jobs with the specified job name")
 	cmd.Flags().StringVar(&ccancel.FlagUserName, "u", "", "Operates only on jobs that are submitted by the specified user")
 	cmd.Flags().StringVar(&ccancel.FlagPartition, "q", "", "Operates only on jobs in the specified queue (partition)")

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -124,6 +124,7 @@ func sacct() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cacct.FlagConfigFilePath)
 	cmd.Flags().StringVarP(&cacct.FlagFilterAccounts, "account", "A", "",
 		"Displays jobs when a comma separated list of accounts are given as the argument.")
 	cmd.Flags().StringVarP(&cacct.FlagFilterJobIDs, "jobs", "j", "",
@@ -280,6 +281,7 @@ func scancel() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &ccancel.FlagConfigFilePath)
 	cmd.Flags().BoolP("help", "", false, "Help for this command.")
 
 	cmd.Flags().StringVarP(&ccancel.FlagAccount, "account", "A", "",
@@ -502,6 +504,7 @@ func sinfo() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	// cmd.Flags().BoolVarP(&cinfo.FlagSummarize, "summarize", "s", false,
 	// 	"List only a partition state summary with no node state details.")
 	// cmd.Flags().BoolVarP(&cinfo.FlagListReason, "list-reasons", "R", false,
@@ -548,6 +551,7 @@ func squeue() *cobra.Command {
 		},
 	}
 
+	addConfigPathFlag(cmd, &cqueue.FlagConfigFilePath)
 	// As --noheader will use -h, we need to add the help flag manually
 	cmd.Flags().BoolP("help", "", false, "Help for this command.")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--config` flag to LSF wrapper commands (bacct, bsub, bjobs, bqueues, bkill) to specify a custom configuration file path.
  * Added `--config` flag to Slurm wrapper commands (sacct, scancel, sinfo, squeue) to specify a custom configuration file path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->