### PR TITLE
fix: fix wrong mapping in cwrapper's scancel squeue sacct

### DIFF
--- a/internal/cbatch/cmd.go
+++ b/internal/cbatch/cmd.go
@@ -70,9 +70,10 @@ var (
 	FlagReservation string
 	FlagSignal      string
 
-	FlagHold      bool
-	FlagBeginTime string
-	FlagDns       []string
+	FlagHold         bool
+	FlagBeginTime    string
+	FlagDns          []string
+	FlagDeadlineTime string
 
 	// not implement feature:
 	FlagNTasks          string
@@ -89,7 +90,6 @@ var (
 	FlagCoresPerSocket  string
 	FlagRequeue         string
 	FlagWait            string
-	FlagDeadlineTime    string
 
 	RootCmd = &cobra.Command{
 		Use:     "cbatch [flags] file",

--- a/internal/ccancel/cmd.go
+++ b/internal/ccancel/cmd.go
@@ -21,7 +21,6 @@ package ccancel
 import (
 	"CraneFrontEnd/internal/util"
 	"regexp"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -35,7 +34,6 @@ var (
 	FlagNodes          []string
 	FlagConfigFilePath string
 	FlagJson           bool
-	FlagWrapper        bool
 
 	RootCmd = &cobra.Command{
 		Use:     "ccancel [flags] JOBID.STEPID[,JOBID.STEPID...]",
@@ -43,6 +41,10 @@ var (
 		Long:    "",
 		Version: util.Version(),
 		Args: func(cmd *cobra.Command, args []string) error {
+			err := cobra.MaximumNArgs(1)(cmd, args)
+			if err != nil {
+				return err
+			}
 
 			if len(args) == 0 &&
 				FlagJobName == "" &&
@@ -54,18 +56,14 @@ var (
 				return util.NewCraneErr(util.ErrorCmdArg, "at least one condition should be given.")
 			}
 
-			if len(args) > 1 && !FlagWrapper {
-				return util.NewCraneErr(util.ErrorCmdArg, "job id list must follow the format "+
-					"<job_id> or '<job_id>,<job_id>,<job_id>...'")
-			}
-
-			if len(args) > 0 && !FlagWrapper {
+			if len(args) > 0 {
 				matched, _ := regexp.MatchString(`^([1-9][0-9]*(\.[1-9][0-9]*)?)(,[1-9][0-9]*(\.[1-9][0-9]*)?)*$`, args[0])
 				if !matched {
 					return util.NewCraneErr(util.ErrorCmdArg, "job id list must follow the format "+
 						"<job_id> or '<job_id>,<job_id>,<job_id>...'")
 				}
 			}
+
 			return nil
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -74,9 +72,6 @@ var (
 			stub = util.GetStubToCtldByConfig(config)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if FlagWrapper && len(args) > 0 {
-				args = []string{strings.Join(args, ",")}
-			}
 			return CancelJob(args)
 		},
 	}
@@ -107,7 +102,5 @@ func init() {
 		"Cancel jobs running or suspended on the specified nodes")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")
-	RootCmd.Flags().BoolVar(&FlagWrapper, "wrapper", false, "Internal flag")
-	RootCmd.Flags().MarkHidden("wrapper")
 	util.InitCraneLogger()
 }

--- a/internal/ccancel/cmd.go
+++ b/internal/ccancel/cmd.go
@@ -21,6 +21,7 @@ package ccancel
 import (
 	"CraneFrontEnd/internal/util"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,7 @@ var (
 	FlagNodes          []string
 	FlagConfigFilePath string
 	FlagJson           bool
+	FlagWrapper        bool
 
 	RootCmd = &cobra.Command{
 		Use:     "ccancel [flags] JOBID.STEPID[,JOBID.STEPID...]",
@@ -41,10 +43,6 @@ var (
 		Long:    "",
 		Version: util.Version(),
 		Args: func(cmd *cobra.Command, args []string) error {
-			err := cobra.MaximumNArgs(1)(cmd, args)
-			if err != nil {
-				return err
-			}
 
 			if len(args) == 0 &&
 				FlagJobName == "" &&
@@ -56,14 +54,18 @@ var (
 				return util.NewCraneErr(util.ErrorCmdArg, "at least one condition should be given.")
 			}
 
-			if len(args) > 0 {
+			if len(args) > 1 && !FlagWrapper {
+				return util.NewCraneErr(util.ErrorCmdArg, "job id list must follow the format "+
+					"<job_id> or '<job_id>,<job_id>,<job_id>...'")
+			}
+
+			if len(args) > 0 && !FlagWrapper {
 				matched, _ := regexp.MatchString(`^([1-9][0-9]*(\.[1-9][0-9]*)?)(,[1-9][0-9]*(\.[1-9][0-9]*)?)*$`, args[0])
 				if !matched {
 					return util.NewCraneErr(util.ErrorCmdArg, "job id list must follow the format "+
 						"<job_id> or '<job_id>,<job_id>,<job_id>...'")
 				}
 			}
-
 			return nil
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -72,6 +74,9 @@ var (
 			stub = util.GetStubToCtldByConfig(config)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if FlagWrapper && len(args) > 0 {
+				args = []string{strings.Join(args, ",")}
+			}
 			return CancelJob(args)
 		},
 	}
@@ -102,5 +107,7 @@ func init() {
 		"Cancel jobs running or suspended on the specified nodes")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")
+	RootCmd.Flags().BoolVar(&FlagWrapper, "wrapper", false, "Internal flag")
+	RootCmd.Flags().MarkHidden("wrapper")
 	util.InitCraneLogger()
 }

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -612,10 +612,7 @@ func scancel() *cobra.Command {
 				ccancelArgs = append(ccancelArgs, "--user", FlagUserName)
 			}
 			if len(FlagNodeList) > 0 {
-				ccancelArgs = append(ccancelArgs, "--nodes")
-				for _, node := range FlagNodeList {
-					ccancelArgs = append(ccancelArgs, node)
-				}
+				ccancelArgs = append(ccancelArgs, "--nodes", strings.Join(FlagNodeList, ","))
 			}
 			if FlagConfigFilePath != "" {
 				ccancelArgs = append(ccancelArgs, "--config", FlagConfigFilePath)

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -137,7 +137,7 @@ func sacct() *cobra.Command {
 				case *util.CraneError:
 					os.Exit(e.Code)
 				default:
-					os.Exit(util.ErrorSuccess)
+					os.Exit(util.ErrorGeneric)
 				}
 			} else {
 				os.Exit(util.ErrorSuccess)
@@ -577,52 +577,86 @@ func salloc() *cobra.Command {
 }
 
 func scancel() *cobra.Command {
+	var (
+		FlagJobName        string
+		FlagPartition      string
+		FlagState          string
+		FlagAccount        string
+		FlagUserName       string
+		FlagNodeList       []string
+		FlagConfigFilePath string
+		FlagJson           bool
+	)
 	cmd := &cobra.Command{
-		Use:                "scancel",
-		Short:              "Wrapper of ccancel command",
-		Long:               "",
-		GroupID:            "slurm",
-		DisableFlagParsing: true,
+		Use:     "scancel",
+		Short:   "Wrapper of ccancel command",
+		Long:    "",
+		GroupID: "slurm",
 		Run: func(cmd *cobra.Command, args []string) {
 			// scancel uses spaced arguments,
 			// we need to convert it into a comma-separated list.
-			convertedArgs := make([]string, 0, len(args)+1)
-			convertedArgs = append(convertedArgs, "--wrapper")
-			for _, arg := range args {
-				switch arg {
-				case "--nodelist":
-					convertedArgs = append(convertedArgs, "--nodes")
-				default:
-					convertedArgs = append(convertedArgs, arg)
+			ccancelArgs := make([]string, 0)
+			if FlagJobName != "" {
+				ccancelArgs = append(ccancelArgs, "--name", FlagJobName)
+			}
+			if FlagPartition != "" {
+				ccancelArgs = append(ccancelArgs, "--partition", FlagPartition)
+			}
+			if FlagState != "" {
+				ccancelArgs = append(ccancelArgs, "--state", FlagState)
+			}
+			if FlagAccount != "" {
+				ccancelArgs = append(ccancelArgs, "--account", FlagAccount)
+			}
+			if FlagUserName != "" {
+				ccancelArgs = append(ccancelArgs, "--user", FlagUserName)
+			}
+			if len(FlagNodeList) > 0 {
+				ccancelArgs = append(ccancelArgs, "--nodes")
+				for _, node := range FlagNodeList {
+					ccancelArgs = append(ccancelArgs, node)
 				}
 			}
-			ccancel.RootCmd.SetArgs(convertedArgs)
+			if FlagConfigFilePath != "" {
+				ccancelArgs = append(ccancelArgs, "--config", FlagConfigFilePath)
+			}
+			if FlagJson {
+				ccancelArgs = append(ccancelArgs, "--json")
+			}
+			if len(args) > 0 {
+				ccancelArgs = append(ccancelArgs, strings.Join(args, ","))
+			}
+			ccancel.RootCmd.SetArgs(ccancelArgs)
 			err := ccancel.RootCmd.Execute()
 			if err != nil {
 				switch e := err.(type) {
 				case *util.CraneError:
 					os.Exit(e.Code)
 				default:
-					os.Exit(util.ErrorSuccess)
+					os.Exit(util.ErrorGeneric)
 				}
 			} else {
 				os.Exit(util.ErrorSuccess)
 			}
 		},
 	}
-
-	addConfigPathFlag(cmd, &ccancel.FlagConfigFilePath)
-	cmd.Flags().StringVarP(&ccancel.FlagAccount, "account", "A", "",
-		"Restrict the scancel operation to jobs under this charge account.")
-	cmd.Flags().StringVarP(&ccancel.FlagJobName, "name", "n", "",
-		"Restrict the scancel operation to jobs with this job name.") // TODO: Alias --jobname
-	cmd.Flags().StringVarP(&ccancel.FlagPartition, "partition", "p", "",
-		"Restrict the scancel operation to jobs in this partition.")
-	cmd.Flags().StringVarP(&ccancel.FlagState, "state", "t", "",
-		`Restrict the scancel operation to jobs in this state.`) // TODO: Give hints on valid state strings
-	cmd.Flags().StringVarP(&ccancel.FlagUserName, "user", "u", "",
-		"Restrict the scancel operation to jobs owned by the given user.")
-
+	addConfigPathFlag(cmd, &FlagConfigFilePath)
+	cmd.Flags().StringVarP(&FlagJobName, "name", "n", "",
+		"Cancel jobs with the specified job name")
+	cmd.Flags().StringVarP(&FlagPartition, "partition", "p", "",
+		"Cancel jobs in the specified partition")
+	cmd.Flags().StringVarP(&FlagState, "state", "t", "",
+		"Cancel jobs of the specified states"+
+			"Valid job states are PENDING(P), RUNNING(R), SUSPENDED(S), ALL. "+
+			"job states are case-insensitive")
+	cmd.Flags().StringVarP(&FlagAccount, "account", "A", "",
+		"Cancel jobs under the specified account")
+	cmd.Flags().StringVarP(&FlagUserName, "user", "u", "",
+		"Cancel jobs submitted by the specified user")
+	cmd.Flags().StringSliceVarP(&FlagNodeList, "nodelist", "w", nil,
+		"Cancel jobs running or suspended on the specified nodes")
+	cmd.Flags().BoolVar(&FlagJson, "json", false,
+		"Output in JSON format")
 	return cmd
 }
 
@@ -963,7 +997,7 @@ func squeue() *cobra.Command {
 				case *util.CraneError:
 					os.Exit(e.Code)
 				default:
-					os.Exit(util.ErrorSuccess)
+					os.Exit(util.ErrorGeneric)
 				}
 			} else {
 				os.Exit(util.ErrorSuccess)

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -591,7 +591,7 @@ func scancel() *cobra.Command {
 			for _, arg := range args {
 				switch arg {
 				case "--nodelist":
-					convertedArgs = append(convertedArgs, " --nodes")
+					convertedArgs = append(convertedArgs, "--nodes")
 				default:
 					convertedArgs = append(convertedArgs, arg)
 				}
@@ -616,8 +616,6 @@ func scancel() *cobra.Command {
 		"Restrict the scancel operation to jobs under this charge account.")
 	cmd.Flags().StringVarP(&ccancel.FlagJobName, "name", "n", "",
 		"Restrict the scancel operation to jobs with this job name.") // TODO: Alias --jobname
-	cmd.Flags().StringSliceVarP(&ccancel.FlagNodes, "nodelist", "w", nil,
-		"Cancel any jobs using any of the given hosts. (comma-separated list of hosts)") // TODO: Read from file
 	cmd.Flags().StringVarP(&ccancel.FlagPartition, "partition", "p", "",
 		"Restrict the scancel operation to jobs in this partition.")
 	cmd.Flags().StringVarP(&ccancel.FlagState, "state", "t", "",

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -109,35 +109,47 @@ func (w SlurmWrapper) Preprocess() error {
 
 func sacct() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "sacct",
-		Short:   "Wrapper of cacct command",
-		Long:    "",
-		GroupID: "slurm",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cacct.RootCmd.PersistentPreRun(cmd, args)
-			if err := Validate(cacct.RootCmd, args); err != nil {
-				log.Error(err)
-				os.Exit(util.ErrorCmdArg)
+		Use:                "sacct",
+		Short:              "Wrapper of cacct command",
+		Long:               "",
+		GroupID:            "slurm",
+		DisableFlagParsing: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			convertedArgs := make([]string, 0, len(args))
+			for _, arg := range args {
+				switch arg {
+				case "--jobs":
+					convertedArgs = append(convertedArgs, "--job")
+				case "--starttime":
+					convertedArgs = append(convertedArgs, "--start-time")
+				case "--endtime":
+					convertedArgs = append(convertedArgs, "--end-time")
+				case "-n":
+					convertedArgs = append(convertedArgs, "-N")
+				default:
+					convertedArgs = append(convertedArgs, arg)
+				}
 			}
-			return cacct.RootCmd.RunE(cmd, args)
+			cacct.RootCmd.SetArgs(convertedArgs)
+			err := cacct.RootCmd.Execute()
+			if err != nil {
+				switch e := err.(type) {
+				case *util.CraneError:
+					os.Exit(e.Code)
+				default:
+					os.Exit(util.ErrorSuccess)
+				}
+			} else {
+				os.Exit(util.ErrorSuccess)
+			}
 		},
 	}
 
 	addConfigPathFlag(cmd, &cacct.FlagConfigFilePath)
 	cmd.Flags().StringVarP(&cacct.FlagFilterAccounts, "account", "A", "",
 		"Displays jobs when a comma separated list of accounts are given as the argument.")
-	cmd.Flags().StringVarP(&cacct.FlagFilterJobIDs, "jobs", "j", "",
-		"Displays information about the specified job or list of jobs.")
 	cmd.Flags().StringVarP(&cacct.FlagFilterUsers, "user", "u", "",
 		"Use this comma separated list of user names to select jobs to display.")
-
-	cmd.Flags().StringVarP(&cacct.FlagFilterStartTime, "starttime", "S", "",
-		"Select jobs in any state after the specified time.")
-	cmd.Flags().StringVarP(&cacct.FlagFilterEndTime, "endtime", "E", "",
-		"Select jobs in any state before the specified time.")
-
-	cmd.Flags().BoolVarP(&cacct.FlagNoHeader, "noheader", "n", false,
-		"No heading will be added to the output. The default action is to display a header.")
 
 	return cmd
 }
@@ -566,29 +578,40 @@ func salloc() *cobra.Command {
 
 func scancel() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "scancel",
-		Short:   "Wrapper of ccancel command",
-		Long:    "",
-		GroupID: "slurm",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Use:                "scancel",
+		Short:              "Wrapper of ccancel command",
+		Long:               "",
+		GroupID:            "slurm",
+		DisableFlagParsing: true,
+		Run: func(cmd *cobra.Command, args []string) {
 			// scancel uses spaced arguments,
 			// we need to convert it into a comma-separated list.
-			if len(args) > 0 {
-				args = []string{strings.Join(args, ",")}
+			convertedArgs := make([]string, 0, len(args)+1)
+			convertedArgs = append(convertedArgs, "--wrapper")
+			for _, arg := range args {
+				switch arg {
+				case "--nodelist":
+					convertedArgs = append(convertedArgs, " --nodes")
+				default:
+					convertedArgs = append(convertedArgs, arg)
+				}
 			}
-
-			ccancel.RootCmd.PersistentPreRun(cmd, args)
-			if err := Validate(ccancel.RootCmd, args); err != nil {
-				log.Error(err)
-				os.Exit(util.ErrorCmdArg)
+			ccancel.RootCmd.SetArgs(convertedArgs)
+			err := ccancel.RootCmd.Execute()
+			if err != nil {
+				switch e := err.(type) {
+				case *util.CraneError:
+					os.Exit(e.Code)
+				default:
+					os.Exit(util.ErrorSuccess)
+				}
+			} else {
+				os.Exit(util.ErrorSuccess)
 			}
-			return ccancel.RootCmd.RunE(cmd, args)
 		},
 	}
 
 	addConfigPathFlag(cmd, &ccancel.FlagConfigFilePath)
-	cmd.Flags().BoolP("help", "", false, "Help for this command.")
-
 	cmd.Flags().StringVarP(&ccancel.FlagAccount, "account", "A", "",
 		"Restrict the scancel operation to jobs under this charge account.")
 	cmd.Flags().StringVarP(&ccancel.FlagJobName, "name", "n", "",
@@ -916,46 +939,51 @@ func sinfo() *cobra.Command {
 
 func squeue() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "squeue",
-		Short:   "Wrapper of cqueue command",
-		Long:    "",
-		GroupID: "slurm",
+		Use:                "squeue",
+		Short:              "Wrapper of cqueue command",
+		Long:               "",
+		GroupID:            "slurm",
+		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cqueue.RootCmd.PersistentPreRun(cmd, args)
-			// Validate the arguments
-			if err := Validate(cqueue.RootCmd, args); err != nil {
-				log.Error(err)
-				os.Exit(util.ErrorCmdArg)
+			convertedArgs := make([]string, 0, len(args))
+			for _, arg := range args {
+				switch arg {
+				case "-h":
+					convertedArgs = append(convertedArgs, "-N")
+				case "--jobs":
+					convertedArgs = append(convertedArgs, "--job")
+				case "--states":
+					convertedArgs = append(convertedArgs, "--state")
+				default:
+					convertedArgs = append(convertedArgs, arg)
+				}
 			}
-
-			err := util.ErrorSuccess
-			if cqueue.FlagIterate != 0 {
-				err = squeueLoopedQuery(cqueue.FlagIterate)
+			cqueue.RootCmd.SetArgs(convertedArgs)
+			err := cqueue.RootCmd.Execute()
+			if err != nil {
+				switch e := err.(type) {
+				case *util.CraneError:
+					os.Exit(e.Code)
+				default:
+					os.Exit(util.ErrorSuccess)
+				}
 			} else {
-				err = squeueQuery()
+				os.Exit(util.ErrorSuccess)
 			}
-			os.Exit(err)
 		},
 	}
 
 	addConfigPathFlag(cmd, &cqueue.FlagConfigFilePath)
 	// As --noheader will use -h, we need to add the help flag manually
 	cmd.Flags().BoolP("help", "", false, "Help for this command.")
-
-	cmd.Flags().BoolVarP(&cqueue.FlagNoHeader, "noheader", "h", false,
-		"Do not print a header on the output.")
 	cmd.Flags().BoolVarP(&cqueue.FlagStartTime, "start", "S", false,
 		"Report the expected start time and resources to be allocated for pending jobs in order of \nincreasing start time.")
 	cmd.Flags().StringVarP(&cqueue.FlagFilterPartitions, "partition", "p", "",
 		"Specify the partitions of the jobs or steps to view. Accepts a comma separated list of \npartition names.")
-	cmd.Flags().StringVarP(&cqueue.FlagFilterJobIDs, "jobs", "j", "",
-		"Specify a comma separated list of job IDs to display. Defaults to all jobs. ")
 	cmd.Flags().StringVarP(&cqueue.FlagFilterJobNames, "name", "n", "",
 		"Request jobs or job steps having one of the specified names. The list consists of a comma \nseparated list of job names.")
 	cmd.Flags().StringVarP(&cqueue.FlagFilterQos, "qos", "q", "",
 		"Specify the qos(s) of the jobs or steps to view. Accepts a comma separated list of qos's.")
-	cmd.Flags().StringVarP(&cqueue.FlagFilterStates, "states", "t", "",
-		"Specify the states of jobs to view. Accepts a comma separated list of state names or \"all\".")
 	cmd.Flags().StringVarP(&cqueue.FlagFilterUsers, "user", "u", "",
 		"Request jobs or job steps from a comma separated list of users.")
 	cmd.Flags().StringVarP(&cqueue.FlagFilterAccounts, "account", "A", "",


### PR DESCRIPTION
cwrapper scancel --nodelists
when passing args to ccancel --nodelist -> --nodes
cwrapper scancel 17 18 19
when passing args to ccancel "17 18 19" -> "17,18,19"
this format is only admitted in cwrapper, using ccancel directly will cause an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined command wrappers for sacct, scancel, and squeue to improve flag mapping and exit-code handling.
* **New Features**
  * scancel now supports a top-level --json output option.
  * Added a top-level --deadline flag for batch submissions.
* **Bug Fixes**
  * Improved handling of node lists, flag aliases, and preservation/forwarding of positional arguments so CLI behavior is more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->