### PR TITLE
refactor: Use template rendering for MetaCNI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ testcase
 *.out
 *.bak
 test/
+
+# Git worktrees
+.worktrees/

--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -342,7 +342,7 @@ CallocStateMachineLoop:
 }
 
 func MainCalloc(cmd *cobra.Command, args []string) error {
-	util.SetupLogger(FlagDebugLevel)
+	util.InitDiagLogger(FlagDebugLevel)
 
 	var err error
 	gVars.globalCtx, gVars.globalCtxCancel = context.WithCancel(context.Background())

--- a/internal/ccon/cmd.go
+++ b/internal/ccon/cmd.go
@@ -45,7 +45,7 @@ var (
 		Version: util.Version(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			util.DetectNetworkProxy()
-			util.SetupLogger(GetFlags().Global.DebugLevel)
+			util.InitDiagLogger(GetFlags().Global.DebugLevel)
 
 			var err error
 			if cmd != RunCmd {
@@ -284,5 +284,4 @@ func init() {
 		cmd.Println("To use crane flags, place them between 'ccon' and 'run', e.g.,\n  ccon -p CPU run ...")
 		return nil
 	})
-	util.InitCraneLogger()
 }

--- a/internal/cfored/cfored.go
+++ b/internal/cfored/cfored.go
@@ -122,7 +122,7 @@ func StartCfored(cmd *cobra.Command) {
 	if !cmd.Flags().Changed("debug-level") && config.Cfored.DebugLevel != "" {
 		debugLevel = config.Cfored.DebugLevel
 	}
-	util.SetupLogger(debugLevel)
+	util.InitDiagLogger(debugLevel)
 
 	util.DetectNetworkProxy()
 
@@ -176,7 +176,7 @@ func SetupAndRunSignalHandlerRoutine(pidFilePath string) {
 					config := util.ParseConfig(FlagConfigFilePath)
 
 					if config.Cfored.DebugLevel != "" {
-						util.SetupLogger(config.Cfored.DebugLevel)
+						util.InitDiagLogger(config.Cfored.DebugLevel)
 						log.Infof("Log level reloaded to %s", config.Cfored.DebugLevel)
 					}
 				case syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:

--- a/internal/cplugind/cplugind.go
+++ b/internal/cplugind/cplugind.go
@@ -63,9 +63,9 @@ var RootCmd = &cobra.Command{
 
 		// Set log level
 		if cmd.Flags().Changed("debug-level") {
-			util.SetupLogger(FlagDebugLevel)
+			util.InitDiagLogger(FlagDebugLevel)
 		} else {
-			util.SetupLogger(gPluginConfig.LogLevel)
+			util.InitDiagLogger(gPluginConfig.LogLevel)
 		}
 
 		// Load plugins

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -1425,7 +1425,7 @@ func (m *StateMachineOfCrun) RunCommand(runCommandArgs RunCommandArgs) int {
 }
 
 func MainCrun(cmd *cobra.Command, args []string) error {
-	util.SetupLogger(FlagDebugLevel)
+	util.InitDiagLogger(FlagDebugLevel)
 
 	gVars.globalCtx, gVars.globalCtxCancel = context.WithCancel(context.Background())
 

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path"
 	"runtime"
+	"strings"
 
 	nested "github.com/antonfisher/nested-logrus-formatter"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +34,10 @@ type CraneFormatter struct {
 
 func (f *CraneFormatter) Format(entry *log.Entry) ([]byte, error) {
 	msg := entry.Message
-	return []byte(msg), nil
+	if strings.HasSuffix(msg, "\n") {
+		return []byte(msg), nil
+	}
+	return append([]byte(msg), '\n'), nil
 }
 
 func InitCraneLogger() {

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -40,17 +40,28 @@ func (f *CraneFormatter) Format(entry *log.Entry) ([]byte, error) {
 	return append([]byte(msg), '\n'), nil
 }
 
+// A simple formatter that only outputs the message,
+// without any timestamp, level or caller info.
+// It's used for normal output of simple commands (excluding cfored/cplugind and ccon/crun...)
 func InitCraneLogger() {
 	log.SetFormatter(&CraneFormatter{})
 }
 
-func SetupLogger(level string) {
-	SetLoggerLevel(level)
-	if level == "debug" || level == "trace" {
+func InitDiagLogger(level string) {
+	lv, err := log.ParseLevel(level)
+	if err != nil {
+		log.Warnf("Invalid log level %s, using info level", level)
+		lv = log.InfoLevel
+	}
+	if lv > log.InfoLevel {
+		// DEBUG/TRACE
 		log.SetReportCaller(true)
 	} else {
+		// INFO/WARN/ERROR/FATAL/PANIC
 		log.SetReportCaller(false)
 	}
+
+	log.SetLevel(lv)
 	log.SetFormatter(&nested.Formatter{
 		HideKeys:    false,
 		CallerFirst: true,
@@ -59,18 +70,4 @@ func SetupLogger(level string) {
 			return fmt.Sprintf(" %s:%d", path.Base(frame.File), frame.Line)
 		},
 	})
-}
-
-func SetLoggerLevel(level string) {
-	switch level {
-	case "trace":
-		log.SetLevel(log.TraceLevel)
-	case "debug":
-		log.SetLevel(log.DebugLevel)
-	case "info":
-		log.SetLevel(log.InfoLevel)
-	default:
-		log.Warnf("Invalid log level %s, using info level", level)
-		log.SetLevel(log.InfoLevel)
-	}
 }

--- a/tool/meta-cni/README.md
+++ b/tool/meta-cni/README.md
@@ -79,7 +79,7 @@ Each entry in a pipeline's `delegates` supports:
 - `conf` (object, optional): Delegate plugin configuration. If omitted, the
   meta plugin will build a minimal config using `type`, `name`, and the parent
   `cniVersion`. String values inside `conf` may contain Go template expressions
-  that are rendered at runtime using `.GRES` and `.ARGS`.
+  that are rendered at runtime using `.Gres` and `.Args`.
 - `runtimeOverride` (object, optional): Per-delegate override (takes precedence
   over pipeline and global overrides).
 
@@ -92,7 +92,7 @@ Simple example:
 ```json
 "conf": {
   "type": "sriov",
-  "deviceID": "{{.GRES.device}}"
+  "deviceID": "{{.Gres.Device}}"
 }
 ```
 
@@ -101,23 +101,23 @@ Conditional example:
 ```json
 "conf": {
   "type": "macvlan",
-  "master": "{{if .ARGS.MASTER}}{{.ARGS.MASTER}}{{else}}eno1{{end}}"
+  "master": "{{if .Args.MASTER}}{{.Args.MASTER}}{{else}}eno1{{end}}"
 }
 ```
 
 Available runtime data:
 
-- `.GRES.device` - the device annotation value for the current template-pipeline instance
-- `.GRES.index` - the template instance index as a string
-- `.ARGS.<KEY>` - a CNI_ARGS entry whose key is a valid Go identifier
-- `index .ARGS "KEY-WITH-DASH"` - access for keys that are not valid Go identifiers
+- `.Gres.Device` - the device annotation value for the current template-pipeline instance
+- `.Gres.Index` - the template instance index as a string
+- `.Args.<KEY>` - a CNI_ARGS entry whose key is a valid Go identifier
+- `index .Args "KEY-WITH-DASH"` - access for keys that are not valid Go identifiers
 
 Rules and limitations:
 
 1. Templates are rendered only inside JSON string values in `conf`.
 2. The renderer uses standard Go `text/template` behavior.
 3. Invalid template syntax and template execution errors fail the pipeline.
-4. Missing `.GRES` / `.ARGS` keys follow Go template zero-value semantics and render as empty strings. Template authors are responsible for ensuring missing data does not produce an invalid delegate config.
+4. Missing `.Args` keys follow Go template zero-value semantics and render as empty strings. `.Gres` only exposes `Device` and `Index`; other `.Gres` fields are invalid.
 5. Rendered fields stay strings; this feature does not generate JSON numbers, booleans, objects, or arrays.
 6. Template pipelines require matching GRES annotations for all actions.
 

--- a/tool/meta-cni/README.md
+++ b/tool/meta-cni/README.md
@@ -100,8 +100,8 @@ Conditional example:
 
 ```json
 "conf": {
-  "type": "plugin",
-  "alias": "{{if .ARGS.ALIAS}}{{.ARGS.ALIAS}}{{else}}rdma{{.GRES.index}}{{end}}"
+  "type": "macvlan",
+  "master": "{{if .ARGS.MASTER}}{{.ARGS.MASTER}}{{else}}eno1{{end}}"
 }
 ```
 
@@ -116,9 +116,10 @@ Rules and limitations:
 
 1. Templates are rendered only inside JSON string values in `conf`.
 2. The renderer uses standard Go `text/template` behavior.
-3. Template parse errors and execution errors fail the pipeline.
-4. Rendered fields stay strings; this feature does not generate JSON numbers, booleans, objects, or arrays.
-5. Template pipelines require matching GRES annotations for all actions.
+3. Invalid template syntax and template execution errors fail the pipeline.
+4. Missing `.GRES` / `.ARGS` keys follow Go template zero-value semantics and render as empty strings. Template authors are responsible for ensuring missing data does not produce an invalid delegate config.
+5. Rendered fields stay strings; this feature does not generate JSON numbers, booleans, objects, or arrays.
+6. Template pipelines require matching GRES annotations for all actions.
 
 ### GRES annotation convention
 

--- a/tool/meta-cni/README.md
+++ b/tool/meta-cni/README.md
@@ -78,15 +78,47 @@ Each entry in a pipeline's `delegates` supports:
 - `type` (string, optional): Delegate plugin type (binary name).
 - `conf` (object, optional): Delegate plugin configuration. If omitted, the
   meta plugin will build a minimal config using `type`, `name`, and the parent
-  `cniVersion`.
+  `cniVersion`. String values inside `conf` may contain Go template expressions
+  that are rendered at runtime using `.GRES` and `.ARGS`.
 - `runtimeOverride` (object, optional): Per-delegate override (takes precedence
   over pipeline and global overrides).
-- `confFromArgs` (map[string]string, optional): Injects runtime variables into
-  the delegate's JSON config. Keys are config field names; values are `$`-prefixed
-  variable references. Available variables:
-  - `$gres.device`: GRES annotation value (device ID) for template instances.
-  - `$gres.index`: Instance index string for template instances.
-  - `$args.<KEY>`: Value from CNI_ARGS.
+
+### Runtime variables in conf
+
+Template expressions run inside string values in `delegates[].conf`.
+
+Simple example:
+
+```json
+"conf": {
+  "type": "sriov",
+  "deviceID": "{{.GRES.device}}"
+}
+```
+
+Conditional example:
+
+```json
+"conf": {
+  "type": "plugin",
+  "alias": "{{if .ARGS.ALIAS}}{{.ARGS.ALIAS}}{{else}}rdma{{.GRES.index}}{{end}}"
+}
+```
+
+Available runtime data:
+
+- `.GRES.device` - the device annotation value for the current template-pipeline instance
+- `.GRES.index` - the template instance index as a string
+- `.ARGS.<KEY>` - a CNI_ARGS entry whose key is a valid Go identifier
+- `index .ARGS "KEY-WITH-DASH"` - access for keys that are not valid Go identifiers
+
+Rules and limitations:
+
+1. Templates are rendered only inside JSON string values in `conf`.
+2. The renderer uses standard Go `text/template` behavior.
+3. Template parse errors and execution errors fail the pipeline.
+4. Rendered fields stay strings; this feature does not generate JSON numbers, booleans, objects, or arrays.
+5. Template pipelines require matching GRES annotations for all actions.
 
 ### GRES annotation convention
 

--- a/tool/meta-cni/README.md
+++ b/tool/meta-cni/README.md
@@ -119,7 +119,7 @@ Rules and limitations:
 3. Invalid template syntax and template execution errors fail the pipeline.
 4. Missing `.Args` keys follow Go template zero-value semantics and render as empty strings. `.Gres` only exposes `Device` and `Index`; other `.Gres` fields are invalid.
 5. Rendered fields stay strings; this feature does not generate JSON numbers, booleans, objects, or arrays.
-6. Template pipelines require matching GRES annotations for all actions.
+6. On `ADD`, `DEL`, and `CHECK`, template pipelines with no matching GRES annotations are skipped.
 
 ### GRES annotation convention
 

--- a/tool/meta-cni/config/00-crane-calico-sriov.conf
+++ b/tool/meta-cni/config/00-crane-calico-sriov.conf
@@ -91,7 +91,7 @@
             "cniVersion": "1.0.0",
             "type": "sriov",
             "trust": "on",
-            "deviceID": "{{.GRES.device}}",
+            "deviceID": "{{.Gres.Device}}",
             "ipam": {
               "type": "host-local",
               "ranges": [

--- a/tool/meta-cni/config/00-crane-calico-sriov.conf
+++ b/tool/meta-cni/config/00-crane-calico-sriov.conf
@@ -91,6 +91,7 @@
             "cniVersion": "1.0.0",
             "type": "sriov",
             "trust": "on",
+            "deviceID": "{{.GRES.device}}",
             "ipam": {
               "type": "host-local",
               "ranges": [
@@ -101,9 +102,12 @@
                 ]
               ]
             }
-          },
-          "confFromArgs": {
-            "deviceID": "$gres.device"
+          }
+        },
+        {
+          "name": "rdma",
+          "conf": {
+            "type": "rdma"
           }
         }
       ]

--- a/tool/meta-cni/config/00-meta.example.conf
+++ b/tool/meta-cni/config/00-meta.example.conf
@@ -67,6 +67,7 @@
           "conf": {
             "type": "sriov",
             "vlan": 0,
+            "deviceID": "{{.GRES.device}}",
             "ipam": {
               "type": "host-local",
               "ranges": [
@@ -77,9 +78,12 @@
                 ]
               ]
             }
-          },
-          "confFromArgs": {
-            "deviceID": "$gres.device"
+          }
+        },
+        {
+          "name": "rdma",
+          "conf": {
+            "type": "rdma"
           }
         }
       ]

--- a/tool/meta-cni/config/00-meta.example.conf
+++ b/tool/meta-cni/config/00-meta.example.conf
@@ -67,7 +67,7 @@
           "conf": {
             "type": "sriov",
             "vlan": 0,
-            "deviceID": "{{.GRES.device}}",
+            "deviceID": "{{.Gres.Device}}",
             "ipam": {
               "type": "host-local",
               "ranges": [

--- a/tool/meta-cni/pkg/engine/engine.go
+++ b/tool/meta-cni/pkg/engine/engine.go
@@ -85,7 +85,8 @@ func resolvePipelines(conf *metatypes.MetaPluginConf, args *skel.CmdArgs) ([]Res
 
 		instances := findGRESAnnotations(annotations, p.Name)
 		if len(instances) == 0 {
-			return nil, fmt.Errorf("meta-cni: pipeline %q requires GRES annotations but none were found", p.Name)
+			// No GRES allocated for this container: skip template pipeline on ADD.
+			continue
 		}
 
 		for _, inst := range instances {
@@ -120,7 +121,8 @@ func resolvePipelinesForDel(conf *metatypes.MetaPluginConf, args *skel.CmdArgs) 
 
 		instances := findGRESAnnotations(annotations, p.Name)
 		if len(instances) == 0 {
-			return nil, fmt.Errorf("meta-cni: pipeline %q requires GRES annotations but none were found", p.Name)
+			// No GRES allocated for this container: skip template pipeline on DEL/CHECK.
+			continue
 		}
 
 		for _, inst := range instances {

--- a/tool/meta-cni/pkg/engine/engine.go
+++ b/tool/meta-cni/pkg/engine/engine.go
@@ -5,20 +5,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"CraneFrontEnd/tool/meta-cni/pkg/result"
+	metatemplate "CraneFrontEnd/tool/meta-cni/pkg/template"
 	metatypes "CraneFrontEnd/tool/meta-cni/pkg/types"
 	"CraneFrontEnd/tool/meta-cni/pkg/utils"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
-	types100 "github.com/containernetworking/cni/pkg/types/100"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -86,8 +85,7 @@ func resolvePipelines(conf *metatypes.MetaPluginConf, args *skel.CmdArgs) ([]Res
 
 		instances := findGRESAnnotations(annotations, p.Name)
 		if len(instances) == 0 {
-			log.Infof("Pipeline %q skipped: no GRES annotations", p.Name)
-			continue
+			return nil, fmt.Errorf("meta-cni: pipeline %q requires GRES annotations but none were found", p.Name)
 		}
 
 		for _, inst := range instances {
@@ -122,11 +120,7 @@ func resolvePipelinesForDel(conf *metatypes.MetaPluginConf, args *skel.CmdArgs) 
 
 		instances := findGRESAnnotations(annotations, p.Name)
 		if len(instances) == 0 {
-			// Fallback: infer from prevResult
-			instances = inferFromPrevResult(conf.PrevResult, p.IfNamePrefix)
-			if len(instances) > 0 && templateRequiresGRESDevice(p) {
-				return nil, fmt.Errorf("meta-cni: pipeline %q DEL/CHECK fallback cannot recover $gres.device from prevResult; keep annotations or persist device mapping", p.Name)
-			}
+			return nil, fmt.Errorf("meta-cni: pipeline %q requires GRES annotations but none were found", p.Name)
 		}
 
 		for _, inst := range instances {
@@ -139,23 +133,6 @@ func resolvePipelinesForDel(conf *metatypes.MetaPluginConf, args *skel.CmdArgs) 
 	}
 
 	return resolved, nil
-}
-
-func templateRequiresGRESDevice(p *metatypes.Pipeline) bool {
-	if p == nil || !p.IsTemplate() {
-		return false
-	}
-
-	for i := range p.Delegates {
-		d := &p.Delegates[i]
-		for _, varRef := range d.ConfFromArgs {
-			if varRef == "$gres.device" {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 type gresInstance struct {
@@ -186,60 +163,10 @@ func findGRESAnnotations(annotations map[string]string, pipelineName string) []g
 	return instances
 }
 
-func inferFromPrevResult(prevResult cnitypes.Result, ifNamePrefix string) []gresInstance {
-	if prevResult == nil {
-		return nil
-	}
-	result100, err := types100.NewResultFromResult(prevResult)
-	if err != nil {
-		log.Warnf("meta-cni: cannot convert prevResult for inference: %v", err)
-		return nil
-	}
-
-	var instances []gresInstance
-	for _, iface := range result100.Interfaces {
-		if iface == nil || iface.Sandbox == "" {
-			continue // skip host-side interfaces
-		}
-		idx, ok := parseTemplateInstanceIndex(iface.Name, ifNamePrefix)
-		if !ok {
-			continue
-		}
-		instances = append(instances, gresInstance{Index: idx, Device: ""})
-	}
-
-	sort.Slice(instances, func(i, j int) bool {
-		return instances[i].Index < instances[j].Index
-	})
-	return instances
-}
-
-func parseTemplateInstanceIndex(ifName, ifNamePrefix string) (int, bool) {
-	if !strings.HasPrefix(ifName, ifNamePrefix) {
-		return 0, false
-	}
-
-	suffix := ifName[len(ifNamePrefix):]
-	if suffix == "" {
-		return 0, false
-	}
-	if len(suffix) > 1 && suffix[0] == '0' {
-		return 0, false
-	}
-
-	idx, err := strconv.Atoi(suffix)
-	if err != nil || idx < 0 {
-		return 0, false
-	}
-	if strconv.Itoa(idx) != suffix {
-		return 0, false
-	}
-
-	return idx, true
-}
-
 func expandTemplate(p *metatypes.Pipeline, index int, device string, cniArgs map[string]string) (ResolvedPipeline, error) {
-	// Deep copy delegates
+	idxStr := strconv.Itoa(index)
+	vars := metatemplate.BuildVars(device, idxStr, cniArgs)
+
 	delegates := make([]metatypes.DelegateEntry, len(p.Delegates))
 	for i, d := range p.Delegates {
 		delegates[i] = metatypes.DelegateEntry{
@@ -248,18 +175,15 @@ func expandTemplate(p *metatypes.Pipeline, index int, device string, cniArgs map
 			RuntimeOverride: d.RuntimeOverride,
 		}
 		if len(d.Conf) > 0 {
-			confCopy := make(json.RawMessage, len(d.Conf))
-			copy(confCopy, d.Conf)
-			delegates[i].Conf = confCopy
-		}
-		if len(d.ConfFromArgs) > 0 {
-			cfaCopy := make(map[string]string, len(d.ConfFromArgs))
-			maps.Copy(cfaCopy, d.ConfFromArgs)
-			delegates[i].ConfFromArgs = cfaCopy
+			rendered, err := metatemplate.Render(d.Conf, vars)
+			if err != nil {
+				return ResolvedPipeline{}, fmt.Errorf("pipeline %q delegate %s: render conf: %w",
+					p.Name, d.Identifier(), err)
+			}
+			delegates[i].Conf = rendered
 		}
 	}
 
-	idxStr := strconv.Itoa(index)
 	expanded := metatypes.Pipeline{
 		Name:            p.Name + "-" + idxStr,
 		IfName:          p.IfNamePrefix + idxStr,
@@ -267,61 +191,11 @@ func expandTemplate(p *metatypes.Pipeline, index int, device string, cniArgs map
 		Delegates:       delegates,
 	}
 
-	// Build variable context
-	vars := map[string]string{
-		"$gres.device": device,
-		"$gres.index":  idxStr,
-	}
-	for k, v := range cniArgs {
-		argKey := "$args." + k
-		if _, exists := vars[argKey]; !exists {
-			vars[argKey] = v
-		}
-	}
-
-	// Resolve confFromArgs
-	for i := range expanded.Delegates {
-		d := &expanded.Delegates[i]
-		if len(d.ConfFromArgs) == 0 {
-			continue
-		}
-		for confKey, varRef := range d.ConfFromArgs {
-			value, ok := vars[varRef]
-			if !ok {
-				log.Warnf("meta-cni: pipeline %q delegate %s: variable %q not found for confKey %q",
-					expanded.Name, d.Identifier(), varRef, confKey)
-				continue
-			}
-			if err := injectIntoConf(&d.Conf, confKey, value); err != nil {
-				return ResolvedPipeline{}, fmt.Errorf("inject %q into delegate %s conf: %w",
-					confKey, d.Identifier(), err)
-			}
-		}
-	}
-
 	return ResolvedPipeline{
 		Pipeline:      expanded,
 		InstanceIndex: index,
 		GRESDevice:    device,
 	}, nil
-}
-
-func injectIntoConf(conf *json.RawMessage, key, value string) error {
-	var payload map[string]any
-	if len(*conf) == 0 {
-		payload = make(map[string]any)
-	} else {
-		if err := json.Unmarshal(*conf, &payload); err != nil {
-			return fmt.Errorf("decode conf: %w", err)
-		}
-	}
-	payload[key] = value
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("encode conf: %w", err)
-	}
-	*conf = data
-	return nil
 }
 
 func validateUniqueIfNames(pipelines []ResolvedPipeline) error {

--- a/tool/meta-cni/pkg/engine/engine_test.go
+++ b/tool/meta-cni/pkg/engine/engine_test.go
@@ -498,7 +498,7 @@ func TestResolvePipelines(t *testing.T) {
 		}
 	})
 
-	t.Run("template without annotations fails", func(t *testing.T) {
+	t.Run("template without annotations is skipped", func(t *testing.T) {
 		t.Parallel()
 		conf := &metatypes.MetaPluginConf{
 			Pipelines: []metatypes.Pipeline{
@@ -507,9 +507,43 @@ func TestResolvePipelines(t *testing.T) {
 			},
 		}
 		args := &skel.CmdArgs{}
-		_, err := resolvePipelines(conf, args)
-		if err == nil {
-			t.Fatal("expected error when template pipeline has no GRES annotations")
+		resolved, err := resolvePipelines(conf, args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 1 {
+			t.Fatalf("len(resolved) = %d, want 1 (template should be skipped)", len(resolved))
+		}
+		if resolved[0].Name != "eth" {
+			t.Errorf("only eth pipeline should remain, got %q", resolved[0].Name)
+		}
+	})
+
+	t.Run("template without annotations is not expanded", func(t *testing.T) {
+		t.Parallel()
+		conf := &metatypes.MetaPluginConf{
+			Pipelines: []metatypes.Pipeline{
+				{
+					Name:         "roce",
+					IfNamePrefix: "roce",
+					Delegates: []metatypes.DelegateEntry{
+						{
+							Name: "sriov",
+							Type: "sriov",
+							// If template expansion were attempted, this would fail.
+							Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{if .Gres.Device}}"}`),
+						},
+					},
+				},
+			},
+		}
+		args := &skel.CmdArgs{}
+		resolved, err := resolvePipelines(conf, args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 0 {
+			t.Fatalf("len(resolved) = %d, want 0", len(resolved))
 		}
 	})
 
@@ -555,7 +589,7 @@ func TestResolvePipelines(t *testing.T) {
 func TestResolvePipelinesForDel(t *testing.T) {
 	t.Parallel()
 
-	t.Run("template pipeline without annotations fails even if prevResult exists", func(t *testing.T) {
+	t.Run("template pipeline without annotations is skipped even if prevResult exists", func(t *testing.T) {
 		t.Parallel()
 
 		conf := &metatypes.MetaPluginConf{
@@ -580,9 +614,81 @@ func TestResolvePipelinesForDel(t *testing.T) {
 			},
 		}
 
-		_, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
-		if err == nil {
-			t.Fatal("expected error when template pipeline has no GRES annotations")
+		resolved, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 0 {
+			t.Fatalf("len(resolved) = %d, want 0", len(resolved))
+		}
+	})
+
+	t.Run("template pipeline without annotations is not expanded on DEL/CHECK", func(t *testing.T) {
+		t.Parallel()
+
+		conf := &metatypes.MetaPluginConf{
+			PluginConf: cnitypes.PluginConf{PrevResult: &types100.Result{
+				CNIVersion: "1.0.0",
+				Interfaces: []*types100.Interface{
+					{Name: "roce0", Sandbox: "/proc/123/ns/net"},
+				},
+			}},
+			Pipelines: []metatypes.Pipeline{
+				{
+					Name:         "roce",
+					IfNamePrefix: "roce",
+					Delegates: []metatypes.DelegateEntry{
+						{
+							Name: "sriov",
+							Type: "sriov",
+							// If template expansion were attempted, this would fail.
+							Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{if .Gres.Device}}"}`),
+						},
+					},
+				},
+			},
+		}
+
+		resolved, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 0 {
+			t.Fatalf("len(resolved) = %d, want 0", len(resolved))
+		}
+	})
+
+	t.Run("static pipeline still resolves when template pipeline is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		conf := &metatypes.MetaPluginConf{
+			PluginConf: cnitypes.PluginConf{PrevResult: &types100.Result{
+				CNIVersion: "1.0.0",
+				Interfaces: []*types100.Interface{
+					{Name: "eth0", Sandbox: "/proc/123/ns/net"},
+				},
+			}},
+			Pipelines: []metatypes.Pipeline{
+				{Name: "eth", IfName: "eth0", Delegates: []metatypes.DelegateEntry{{Name: "bridge", Type: "bridge"}}},
+				{
+					Name:         "roce",
+					IfNamePrefix: "roce",
+					Delegates: []metatypes.DelegateEntry{
+						{Name: "sriov", Type: "sriov", Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`)},
+					},
+				},
+			},
+		}
+
+		resolved, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 1 {
+			t.Fatalf("len(resolved) = %d, want 1", len(resolved))
+		}
+		if resolved[0].Name != "eth" || resolved[0].IfName != "eth0" {
+			t.Fatalf("resolved[0] = name=%q ifName=%q, want eth/eth0", resolved[0].Name, resolved[0].IfName)
 		}
 	})
 

--- a/tool/meta-cni/pkg/engine/engine_test.go
+++ b/tool/meta-cni/pkg/engine/engine_test.go
@@ -106,93 +106,6 @@ func TestFindGRESAnnotations(t *testing.T) {
 	}
 }
 
-func TestInferFromPrevResult(t *testing.T) {
-	t.Parallel()
-
-	t.Run("nil prevResult", func(t *testing.T) {
-		t.Parallel()
-		got := inferFromPrevResult(nil, "roce")
-		if got != nil {
-			t.Errorf("expected nil, got %v", got)
-		}
-	})
-
-	t.Run("matches container interfaces", func(t *testing.T) {
-		t.Parallel()
-		prev := &types100.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*types100.Interface{
-				{Name: "eth0", Sandbox: "/proc/123/ns/net"},  // static, skip
-				{Name: "roce0", Sandbox: "/proc/123/ns/net"}, // match
-				{Name: "roce1", Sandbox: "/proc/123/ns/net"}, // match
-				{Name: "veth1234", Sandbox: ""},              // host-side, skip
-				{Name: "ib0", Sandbox: "/proc/123/ns/net"},   // different prefix, skip
-			},
-		}
-		got := inferFromPrevResult(prev, "roce")
-		want := []gresInstance{
-			{Index: 0, Device: ""},
-			{Index: 1, Device: ""},
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("inferFromPrevResult() = %v, want %v", got, want)
-		}
-	})
-
-	t.Run("no matching interfaces", func(t *testing.T) {
-		t.Parallel()
-		prev := &types100.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*types100.Interface{
-				{Name: "eth0", Sandbox: "/proc/123/ns/net"},
-			},
-		}
-		got := inferFromPrevResult(prev, "roce")
-		if got != nil {
-			t.Errorf("expected nil, got %v", got)
-		}
-	})
-
-	t.Run("digit-suffixed prefix infers correct index", func(t *testing.T) {
-		t.Parallel()
-		prev := &types100.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*types100.Interface{
-				{Name: "eth12", Sandbox: "/proc/123/ns/net"},
-				{Name: "eth101", Sandbox: "/proc/123/ns/net"},
-				{Name: "eth1001", Sandbox: "/proc/123/ns/net"},
-			},
-		}
-
-		got := inferFromPrevResult(prev, "eth1")
-		want := []gresInstance{
-			{Index: 2, Device: ""},
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("inferFromPrevResult() = %v, want %v", got, want)
-		}
-	})
-
-	t.Run("non-canonical numeric suffix is ignored", func(t *testing.T) {
-		t.Parallel()
-		prev := &types100.Result{
-			CNIVersion: "1.0.0",
-			Interfaces: []*types100.Interface{
-				{Name: "eth101", Sandbox: "/proc/123/ns/net"},
-				{Name: "eth1001", Sandbox: "/proc/123/ns/net"},
-			},
-		}
-
-		got := inferFromPrevResult(prev, "eth10")
-		want := []gresInstance{
-			{Index: 1, Device: ""},
-		}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("inferFromPrevResult() = %v, want %v", got, want)
-		}
-	})
-}
-
 func TestExpandTemplate(t *testing.T) {
 	t.Parallel()
 
@@ -203,19 +116,14 @@ func TestExpandTemplate(t *testing.T) {
 			{
 				Name: "sriov",
 				Type: "sriov",
-				Conf: json.RawMessage(`{"type": "sriov", "vlan": 0}`),
-				ConfFromArgs: map[string]string{
-					"deviceID": "$gres.device",
-				},
+				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
 			},
 		},
 	}
 
-	cniArgs := map[string]string{"FOO": "bar"}
-
-	rp, err := expandTemplate(pipeline, 0, "0000:86:00.2", cniArgs)
+	rp, err := expandTemplate(pipeline, 0, "0000:86:00.2", map[string]string{"FOO": "bar"})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expandTemplate() error = %v", err)
 	}
 
 	if rp.Name != "roce-0" {
@@ -231,15 +139,13 @@ func TestExpandTemplate(t *testing.T) {
 		t.Errorf("gresDevice = %q, want %q", rp.GRESDevice, "0000:86:00.2")
 	}
 
-	// Check conf injection
 	var conf map[string]any
 	if err := json.Unmarshal(rp.Delegates[0].Conf, &conf); err != nil {
 		t.Fatalf("unmarshal conf: %v", err)
 	}
 	if conf["deviceID"] != "0000:86:00.2" {
-		t.Errorf("deviceID = %v, want %q", conf["deviceID"], "0000:86:00.2")
+		t.Fatalf("deviceID = %v, want %q", conf["deviceID"], "0000:86:00.2")
 	}
-	// Original fields preserved
 	if conf["type"] != "sriov" {
 		t.Errorf("type = %v, want %q", conf["type"], "sriov")
 	}
@@ -255,10 +161,7 @@ func TestExpandTemplateWithArgsVar(t *testing.T) {
 			{
 				Name: "plug",
 				Type: "plug",
-				Conf: json.RawMessage(`{"type": "plug"}`),
-				ConfFromArgs: map[string]string{
-					"customField": "$args.MY_KEY",
-				},
+				Conf: json.RawMessage(`{"type":"plug","customField":"{{.ARGS.MY_KEY}}"}`),
 			},
 		},
 	}
@@ -287,15 +190,11 @@ func TestExpandTemplateDeepCopy(t *testing.T) {
 			{
 				Name: "sriov",
 				Type: "sriov",
-				Conf: json.RawMessage(`{"type": "sriov"}`),
-				ConfFromArgs: map[string]string{
-					"deviceID": "$gres.device",
-				},
+				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
 			},
 		},
 	}
 
-	// Expand twice with different devices
 	rp0, err := expandTemplate(original, 0, "dev0", nil)
 	if err != nil {
 		t.Fatalf("expand 0: %v", err)
@@ -305,7 +204,6 @@ func TestExpandTemplateDeepCopy(t *testing.T) {
 		t.Fatalf("expand 1: %v", err)
 	}
 
-	// Verify they don't share the same conf slice
 	var conf0, conf1 map[string]any
 	json.Unmarshal(rp0.Delegates[0].Conf, &conf0)
 	json.Unmarshal(rp1.Delegates[0].Conf, &conf1)
@@ -317,54 +215,12 @@ func TestExpandTemplateDeepCopy(t *testing.T) {
 		t.Errorf("instance 1 deviceID = %v, want dev1", conf1["deviceID"])
 	}
 
-	// Original should not be mutated
+	// Original Conf should still contain the template placeholder.
 	var origConf map[string]any
 	json.Unmarshal(original.Delegates[0].Conf, &origConf)
-	if _, ok := origConf["deviceID"]; ok {
-		t.Error("original conf was mutated by expandTemplate")
+	if origConf["deviceID"] != "{{.GRES.device}}" {
+		t.Errorf("original conf was mutated by expandTemplate: %v", origConf["deviceID"])
 	}
-}
-
-func TestInjectIntoConf(t *testing.T) {
-	t.Parallel()
-
-	t.Run("inject into existing conf", func(t *testing.T) {
-		t.Parallel()
-		conf := json.RawMessage(`{"type": "sriov", "vlan": 0}`)
-		if err := injectIntoConf(&conf, "deviceID", "0000:86:00.2"); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		var payload map[string]any
-		json.Unmarshal(conf, &payload)
-		if payload["deviceID"] != "0000:86:00.2" {
-			t.Errorf("deviceID = %v, want %q", payload["deviceID"], "0000:86:00.2")
-		}
-		if payload["type"] != "sriov" {
-			t.Errorf("type = %v, want sriov (should be preserved)", payload["type"])
-		}
-	})
-
-	t.Run("inject into empty conf", func(t *testing.T) {
-		t.Parallel()
-		conf := json.RawMessage(nil)
-		if err := injectIntoConf(&conf, "key", "value"); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		var payload map[string]any
-		json.Unmarshal(conf, &payload)
-		if payload["key"] != "value" {
-			t.Errorf("key = %v, want %q", payload["key"], "value")
-		}
-	})
-
-	t.Run("invalid conf returns error", func(t *testing.T) {
-		t.Parallel()
-		conf := json.RawMessage(`{invalid`)
-		err := injectIntoConf(&conf, "key", "value")
-		if err == nil {
-			t.Fatal("expected error for invalid JSON")
-		}
-	})
 }
 
 func TestValidateUniqueIfNames(t *testing.T) {
@@ -463,7 +319,6 @@ func TestBuildRuntimeEnv(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// delegate override (layer 4) should win
 		if env["CNI_IFNAME"] != "delegate-override" {
 			t.Errorf("CNI_IFNAME = %q, want %q", env["CNI_IFNAME"], "delegate-override")
 		}
@@ -610,8 +465,8 @@ func TestResolvePipelines(t *testing.T) {
 		conf := &metatypes.MetaPluginConf{
 			Pipelines: []metatypes.Pipeline{
 				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
-					{Name: "sriov", Type: "sriov", Conf: json.RawMessage(`{"type":"sriov"}`),
-						ConfFromArgs: map[string]string{"deviceID": "$gres.device"}},
+					{Name: "sriov", Type: "sriov",
+						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)},
 				}},
 			},
 			RuntimeConfig: map[string]any{
@@ -636,7 +491,6 @@ func TestResolvePipelines(t *testing.T) {
 			t.Errorf("instance 1: name=%q ifName=%q", resolved[1].Name, resolved[1].IfName)
 		}
 
-		// Verify conf injection
 		var conf0 map[string]any
 		json.Unmarshal(resolved[0].Delegates[0].Conf, &conf0)
 		if conf0["deviceID"] != "0000:86:00.2" {
@@ -644,7 +498,7 @@ func TestResolvePipelines(t *testing.T) {
 		}
 	})
 
-	t.Run("template without annotations is skipped", func(t *testing.T) {
+	t.Run("template without annotations fails", func(t *testing.T) {
 		t.Parallel()
 		conf := &metatypes.MetaPluginConf{
 			Pipelines: []metatypes.Pipeline{
@@ -653,15 +507,9 @@ func TestResolvePipelines(t *testing.T) {
 			},
 		}
 		args := &skel.CmdArgs{}
-		resolved, err := resolvePipelines(conf, args)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resolved) != 1 {
-			t.Fatalf("len(resolved) = %d, want 1 (template should be skipped)", len(resolved))
-		}
-		if resolved[0].Name != "eth" {
-			t.Errorf("only eth pipeline should remain, got %q", resolved[0].Name)
+		_, err := resolvePipelines(conf, args)
+		if err == nil {
+			t.Fatal("expected error when template pipeline has no GRES annotations")
 		}
 	})
 
@@ -690,7 +538,6 @@ func TestResolvePipelines(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// eth(static) + roce-0 + ib-0 + ib-1
 		if len(resolved) != 4 {
 			t.Fatalf("len(resolved) = %d, want 4", len(resolved))
 		}
@@ -708,8 +555,9 @@ func TestResolvePipelines(t *testing.T) {
 func TestResolvePipelinesForDel(t *testing.T) {
 	t.Parallel()
 
-	t.Run("fallback fails when template requires gres.device", func(t *testing.T) {
+	t.Run("template pipeline without annotations fails even if prevResult exists", func(t *testing.T) {
 		t.Parallel()
+
 		conf := &metatypes.MetaPluginConf{
 			PluginConf: cnitypes.PluginConf{PrevResult: &types100.Result{
 				CNIVersion: "1.0.0",
@@ -718,49 +566,27 @@ func TestResolvePipelinesForDel(t *testing.T) {
 				},
 			}},
 			Pipelines: []metatypes.Pipeline{
-				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
-					{Name: "sriov", Type: "sriov", Conf: json.RawMessage(`{"type":"sriov"}`),
-						ConfFromArgs: map[string]string{"deviceID": "$gres.device"}},
-				}},
+				{
+					Name:         "roce",
+					IfNamePrefix: "roce",
+					Delegates: []metatypes.DelegateEntry{
+						{
+							Name: "sriov",
+							Type: "sriov",
+							Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
+						},
+					},
+				},
 			},
 		}
 
 		_, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
 		if err == nil {
-			t.Fatal("expected error when $gres.device cannot be recovered from prevResult")
+			t.Fatal("expected error when template pipeline has no GRES annotations")
 		}
 	})
 
-	t.Run("fallback succeeds when template does not require gres.device", func(t *testing.T) {
-		t.Parallel()
-		conf := &metatypes.MetaPluginConf{
-			PluginConf: cnitypes.PluginConf{PrevResult: &types100.Result{
-				CNIVersion: "1.0.0",
-				Interfaces: []*types100.Interface{
-					{Name: "roce0", Sandbox: "/proc/123/ns/net"},
-				},
-			}},
-			Pipelines: []metatypes.Pipeline{
-				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
-					{Name: "sriov", Type: "sriov", Conf: json.RawMessage(`{"type":"sriov"}`),
-						ConfFromArgs: map[string]string{"queue": "$gres.index"}},
-				}},
-			},
-		}
-
-		resolved, err := resolvePipelinesForDel(conf, &skel.CmdArgs{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(resolved) != 1 {
-			t.Fatalf("len(resolved) = %d, want 1", len(resolved))
-		}
-		if resolved[0].Name != "roce-0" || resolved[0].IfName != "roce0" {
-			t.Errorf("resolved pipeline: name=%q ifName=%q", resolved[0].Name, resolved[0].IfName)
-		}
-	})
-
-	t.Run("annotations take precedence and provide gres.device", func(t *testing.T) {
+	t.Run("annotations allow DEL resolution", func(t *testing.T) {
 		t.Parallel()
 		conf := &metatypes.MetaPluginConf{
 			PluginConf: cnitypes.PluginConf{PrevResult: &types100.Result{
@@ -769,8 +595,8 @@ func TestResolvePipelinesForDel(t *testing.T) {
 			}},
 			Pipelines: []metatypes.Pipeline{
 				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
-					{Name: "sriov", Type: "sriov", Conf: json.RawMessage(`{"type":"sriov"}`),
-						ConfFromArgs: map[string]string{"deviceID": "$gres.device"}},
+					{Name: "sriov", Type: "sriov",
+						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)},
 				}},
 			},
 			RuntimeConfig: map[string]any{

--- a/tool/meta-cni/pkg/engine/engine_test.go
+++ b/tool/meta-cni/pkg/engine/engine_test.go
@@ -116,7 +116,7 @@ func TestExpandTemplate(t *testing.T) {
 			{
 				Name: "sriov",
 				Type: "sriov",
-				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
+				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`),
 			},
 		},
 	}
@@ -161,7 +161,7 @@ func TestExpandTemplateWithArgsVar(t *testing.T) {
 			{
 				Name: "plug",
 				Type: "plug",
-				Conf: json.RawMessage(`{"type":"plug","customField":"{{.ARGS.MY_KEY}}"}`),
+				Conf: json.RawMessage(`{"type":"plug","customField":"{{.Args.MY_KEY}}"}`),
 			},
 		},
 	}
@@ -190,7 +190,7 @@ func TestExpandTemplateDeepCopy(t *testing.T) {
 			{
 				Name: "sriov",
 				Type: "sriov",
-				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
+				Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`),
 			},
 		},
 	}
@@ -218,7 +218,7 @@ func TestExpandTemplateDeepCopy(t *testing.T) {
 	// Original Conf should still contain the template placeholder.
 	var origConf map[string]any
 	json.Unmarshal(original.Delegates[0].Conf, &origConf)
-	if origConf["deviceID"] != "{{.GRES.device}}" {
+	if origConf["deviceID"] != "{{.Gres.Device}}" {
 		t.Errorf("original conf was mutated by expandTemplate: %v", origConf["deviceID"])
 	}
 }
@@ -466,7 +466,7 @@ func TestResolvePipelines(t *testing.T) {
 			Pipelines: []metatypes.Pipeline{
 				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
 					{Name: "sriov", Type: "sriov",
-						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)},
+						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`)},
 				}},
 			},
 			RuntimeConfig: map[string]any{
@@ -573,7 +573,7 @@ func TestResolvePipelinesForDel(t *testing.T) {
 						{
 							Name: "sriov",
 							Type: "sriov",
-							Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`),
+							Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`),
 						},
 					},
 				},
@@ -596,7 +596,7 @@ func TestResolvePipelinesForDel(t *testing.T) {
 			Pipelines: []metatypes.Pipeline{
 				{Name: "roce", IfNamePrefix: "roce", Delegates: []metatypes.DelegateEntry{
 					{Name: "sriov", Type: "sriov",
-						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)},
+						Conf: json.RawMessage(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`)},
 				}},
 			},
 			RuntimeConfig: map[string]any{

--- a/tool/meta-cni/pkg/template/template.go
+++ b/tool/meta-cni/pkg/template/template.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	gotemplate "text/template"
 )
 
@@ -65,11 +66,15 @@ func Render(raw []byte, vars Vars) ([]byte, error) {
 }
 
 func renderValue(v any, vars Vars) (any, error) {
+	return renderValueAt(v, vars, "$")
+}
+
+func renderValueAt(v any, vars Vars, path string) (any, error) {
 	switch typed := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(typed))
 		for k, child := range typed {
-			rendered, err := renderValue(child, vars)
+			rendered, err := renderValueAt(child, vars, jsonObjectPath(path, k))
 			if err != nil {
 				return nil, err
 			}
@@ -79,7 +84,7 @@ func renderValue(v any, vars Vars) (any, error) {
 	case []any:
 		out := make([]any, len(typed))
 		for i, child := range typed {
-			rendered, err := renderValue(child, vars)
+			rendered, err := renderValueAt(child, vars, jsonArrayPath(path, i))
 			if err != nil {
 				return nil, err
 			}
@@ -87,21 +92,29 @@ func renderValue(v any, vars Vars) (any, error) {
 		}
 		return out, nil
 	case string:
-		return renderString(typed, vars)
+		return renderString(typed, vars, path)
 	default:
 		return v, nil
 	}
 }
 
-func renderString(raw string, vars Vars) (string, error) {
+func renderString(raw string, vars Vars, path string) (string, error) {
 	tmpl, err := gotemplate.New("conf-string").Option("missingkey=zero").Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("parse template string %q: %w", raw, err)
+		return "", fmt.Errorf("parse template string at %s: %w", path, err)
 	}
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, vars); err != nil {
-		return "", fmt.Errorf("execute template string %q: %w", raw, err)
+		return "", fmt.Errorf("execute template string at %s: %w", path, err)
 	}
 	return buf.String(), nil
+}
+
+func jsonObjectPath(path, key string) string {
+	return path + "[" + strconv.Quote(key) + "]"
+}
+
+func jsonArrayPath(path string, index int) string {
+	return path + "[" + strconv.Itoa(index) + "]"
 }

--- a/tool/meta-cni/pkg/template/template.go
+++ b/tool/meta-cni/pkg/template/template.go
@@ -4,12 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	gotemplate "text/template"
 )
 
 type Vars struct {
-	GRES map[string]string
-	ARGS map[string]string
+	Gres GresVars
+	Args map[string]string
+}
+
+type GresVars struct {
+	Device string
+	Index  string
 }
 
 func BuildVars(gresDevice, gresIndex string, cniArgs map[string]string) Vars {
@@ -19,11 +25,11 @@ func BuildVars(gresDevice, gresIndex string, cniArgs map[string]string) Vars {
 	}
 
 	return Vars{
-		GRES: map[string]string{
-			"device": gresDevice,
-			"index":  gresIndex,
+		Gres: GresVars{
+			Device: gresDevice,
+			Index:  gresIndex,
 		},
-		ARGS: argsCopy,
+		Args: argsCopy,
 	}
 }
 
@@ -33,7 +39,16 @@ func Render(raw []byte, vars Vars) ([]byte, error) {
 	}
 
 	var payload any
-	if err := json.Unmarshal(raw, &payload); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode conf: %w", err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("decode conf: trailing data after JSON value")
+		}
 		return nil, fmt.Errorf("decode conf: %w", err)
 	}
 

--- a/tool/meta-cni/pkg/template/template.go
+++ b/tool/meta-cni/pkg/template/template.go
@@ -1,0 +1,21 @@
+package template
+
+type Vars struct {
+	GRES map[string]string
+	ARGS map[string]string
+}
+
+func BuildVars(gresDevice, gresIndex string, cniArgs map[string]string) Vars {
+	argsCopy := make(map[string]string, len(cniArgs))
+	for k, v := range cniArgs {
+		argsCopy[k] = v
+	}
+
+	return Vars{
+		GRES: map[string]string{
+			"device": gresDevice,
+			"index":  gresIndex,
+		},
+		ARGS: argsCopy,
+	}
+}

--- a/tool/meta-cni/pkg/template/template.go
+++ b/tool/meta-cni/pkg/template/template.go
@@ -1,5 +1,12 @@
 package template
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	gotemplate "text/template"
+)
+
 type Vars struct {
 	GRES map[string]string
 	ARGS map[string]string
@@ -18,4 +25,68 @@ func BuildVars(gresDevice, gresIndex string, cniArgs map[string]string) Vars {
 		},
 		ARGS: argsCopy,
 	}
+}
+
+func Render(raw []byte, vars Vars) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode conf: %w", err)
+	}
+
+	rendered, err := renderValue(payload, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := json.Marshal(rendered)
+	if err != nil {
+		return nil, fmt.Errorf("encode rendered conf: %w", err)
+	}
+	return out, nil
+}
+
+func renderValue(v any, vars Vars) (any, error) {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, child := range typed {
+			rendered, err := renderValue(child, vars)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = rendered
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(typed))
+		for i, child := range typed {
+			rendered, err := renderValue(child, vars)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = rendered
+		}
+		return out, nil
+	case string:
+		return renderString(typed, vars)
+	default:
+		return v, nil
+	}
+}
+
+func renderString(raw string, vars Vars) (string, error) {
+	tmpl, err := gotemplate.New("conf-string").Option("missingkey=zero").Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse template string %q: %w", raw, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vars); err != nil {
+		return "", fmt.Errorf("execute template string %q: %w", raw, err)
+	}
+	return buf.String(), nil
 }

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -217,5 +218,37 @@ func TestRenderBadTemplateErrors(t *testing.T) {
 	_, err := Render(raw, BuildVars("dev0", "0", nil))
 	if err == nil {
 		t.Fatal("expected parse error")
+	}
+}
+
+func TestRenderParseErrorDoesNotLeakTemplateValue(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"note":"token=super-secret {{if .Gres.Device}}"}`)
+	_, err := Render(raw, BuildVars("dev0", "0", nil))
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), `$["note"]`) {
+		t.Fatalf("error %q does not include JSON path", err)
+	}
+	if strings.Contains(err.Error(), "super-secret") {
+		t.Fatalf("error %q leaked raw template value", err)
+	}
+}
+
+func TestRenderExecuteErrorDoesNotLeakTemplateValue(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"note":"token=super-secret {{.Gres.Missing}}"}`)
+	_, err := Render(raw, BuildVars("dev0", "0", nil))
+	if err == nil {
+		t.Fatal("expected execute error")
+	}
+	if !strings.Contains(err.Error(), `$["note"]`) {
+		t.Fatalf("error %q does not include JSON path", err)
+	}
+	if strings.Contains(err.Error(), "super-secret") {
+		t.Fatalf("error %q leaked raw template value", err)
 	}
 }

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -1,0 +1,21 @@
+package template
+
+import "testing"
+
+func TestBuildVars(t *testing.T) {
+	t.Parallel()
+
+	vars := BuildVars("0000:86:00.2", "3", map[string]string{
+		"MY_KEY": "my_value",
+	})
+
+	if vars.GRES["device"] != "0000:86:00.2" {
+		t.Fatalf("GRES.device = %q, want %q", vars.GRES["device"], "0000:86:00.2")
+	}
+	if vars.GRES["index"] != "3" {
+		t.Fatalf("GRES.index = %q, want %q", vars.GRES["index"], "3")
+	}
+	if vars.ARGS["MY_KEY"] != "my_value" {
+		t.Fatalf("ARGS.MY_KEY = %q, want %q", vars.ARGS["MY_KEY"], "my_value")
+	}
+}

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -99,6 +99,49 @@ func TestRenderAllowsBuiltInTemplateSyntax(t *testing.T) {
 	}
 }
 
+func TestRenderMissingDirectKeyUsesZeroValue(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"missingArg":"{{.ARGS.MISSING}}",
+		"missingGRES":"{{.GRES.missing}}"
+	}`)
+
+	out, err := Render(raw, BuildVars("dev0", "7", map[string]string{}))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got["missingArg"] != "" {
+		t.Fatalf("missingArg = %q, want empty string", got["missingArg"])
+	}
+	if got["missingGRES"] != "" {
+		t.Fatalf("missingGRES = %q, want empty string", got["missingGRES"])
+	}
+}
+
+func TestRenderMissingIndexedKeyUsesZeroValue(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"missingDashed":"{{index .ARGS \"MISSING-DASH\"}}"}`)
+	out, err := Render(raw, BuildVars("", "", map[string]string{}))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got["missingDashed"] != "" {
+		t.Fatalf("missingDashed = %q, want empty string", got["missingDashed"])
+	}
+}
+
 func TestRenderKeepsOutputValidJSON(t *testing.T) {
 	t.Parallel()
 

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -43,7 +43,7 @@ func TestRenderSimple(t *testing.T) {
 }
 
 func TestRenderNestedValues(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 
 	raw := []byte(`{
 		"type":"plugin",

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -1,6 +1,9 @@
 package template
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestBuildVars(t *testing.T) {
 	t.Parallel()
@@ -17,5 +20,111 @@ func TestBuildVars(t *testing.T) {
 	}
 	if vars.ARGS["MY_KEY"] != "my_value" {
 		t.Fatalf("ARGS.MY_KEY = %q, want %q", vars.ARGS["MY_KEY"], "my_value")
+	}
+}
+
+func TestRenderSimple(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)
+	out, err := Render(raw, BuildVars("0000:86:00.2", "0", nil))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got["deviceID"] != "0000:86:00.2" {
+		t.Fatalf("deviceID = %v, want %q", got["deviceID"], "0000:86:00.2")
+	}
+}
+
+func TestRenderNestedValues(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"type":"plugin",
+		"labels":["{{.GRES.index}}","fixed"],
+		"nested":{"alias":"{{.ARGS.ALIAS}}"}
+	}`)
+
+	out, err := Render(raw, BuildVars("dev0", "2", map[string]string{
+		"ALIAS": "rdma2",
+	}))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got struct {
+		Labels []string          `json:"labels"`
+		Nested map[string]string `json:"nested"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got.Labels[0] != "2" {
+		t.Fatalf("labels[0] = %q, want %q", got.Labels[0], "2")
+	}
+	if got.Nested["alias"] != "rdma2" {
+		t.Fatalf("nested.alias = %q, want %q", got.Nested["alias"], "rdma2")
+	}
+}
+
+func TestRenderAllowsBuiltInTemplateSyntax(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"alias":"{{if .ARGS.ALIAS}}{{.ARGS.ALIAS}}{{else}}rdma{{.GRES.index}}{{end}}",
+		"dashed":"{{index .ARGS \"KEY-WITH-DASH\"}}"
+	}`)
+
+	out, err := Render(raw, BuildVars("dev0", "7", map[string]string{
+		"KEY-WITH-DASH": "dash-value",
+	}))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got["alias"] != "rdma7" {
+		t.Fatalf("alias = %q, want %q", got["alias"], "rdma7")
+	}
+	if got["dashed"] != "dash-value" {
+		t.Fatalf("dashed = %q, want %q", got["dashed"], "dash-value")
+	}
+}
+
+func TestRenderKeepsOutputValidJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"note":"{{.ARGS.TEXT}}"}`)
+	out, err := Render(raw, BuildVars("", "", map[string]string{
+		"TEXT": `a"b\c`,
+	}))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (output=%s)", err, string(out))
+	}
+	if got["note"] != `a"b\c` {
+		t.Fatalf("note = %q, want %q", got["note"], `a"b\c`)
+	}
+}
+
+func TestRenderBadTemplateErrors(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"note":"{{if .GRES.device}}"}`)
+	_, err := Render(raw, BuildVars("dev0", "0", nil))
+	if err == nil {
+		t.Fatal("expected parse error")
 	}
 }

--- a/tool/meta-cni/pkg/template/template_test.go
+++ b/tool/meta-cni/pkg/template/template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -12,21 +13,21 @@ func TestBuildVars(t *testing.T) {
 		"MY_KEY": "my_value",
 	})
 
-	if vars.GRES["device"] != "0000:86:00.2" {
-		t.Fatalf("GRES.device = %q, want %q", vars.GRES["device"], "0000:86:00.2")
+	if vars.Gres.Device != "0000:86:00.2" {
+		t.Fatalf("Gres.Device = %q, want %q", vars.Gres.Device, "0000:86:00.2")
 	}
-	if vars.GRES["index"] != "3" {
-		t.Fatalf("GRES.index = %q, want %q", vars.GRES["index"], "3")
+	if vars.Gres.Index != "3" {
+		t.Fatalf("Gres.Index = %q, want %q", vars.Gres.Index, "3")
 	}
-	if vars.ARGS["MY_KEY"] != "my_value" {
-		t.Fatalf("ARGS.MY_KEY = %q, want %q", vars.ARGS["MY_KEY"], "my_value")
+	if vars.Args["MY_KEY"] != "my_value" {
+		t.Fatalf("Args.MY_KEY = %q, want %q", vars.Args["MY_KEY"], "my_value")
 	}
 }
 
 func TestRenderSimple(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`{"type":"sriov","deviceID":"{{.GRES.device}}"}`)
+	raw := []byte(`{"type":"sriov","deviceID":"{{.Gres.Device}}"}`)
 	out, err := Render(raw, BuildVars("0000:86:00.2", "0", nil))
 	if err != nil {
 		t.Fatalf("Render() error = %v", err)
@@ -42,12 +43,12 @@ func TestRenderSimple(t *testing.T) {
 }
 
 func TestRenderNestedValues(t *testing.T) {
-	t.Parallel()
+		t.Parallel()
 
 	raw := []byte(`{
 		"type":"plugin",
-		"labels":["{{.GRES.index}}","fixed"],
-		"nested":{"alias":"{{.ARGS.ALIAS}}"}
+		"labels":["{{.Gres.Index}}","fixed"],
+		"nested":{"alias":"{{.Args.ALIAS}}"}
 	}`)
 
 	out, err := Render(raw, BuildVars("dev0", "2", map[string]string{
@@ -76,8 +77,8 @@ func TestRenderAllowsBuiltInTemplateSyntax(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`{
-		"alias":"{{if .ARGS.ALIAS}}{{.ARGS.ALIAS}}{{else}}rdma{{.GRES.index}}{{end}}",
-		"dashed":"{{index .ARGS \"KEY-WITH-DASH\"}}"
+		"alias":"{{if .Args.ALIAS}}{{.Args.ALIAS}}{{else}}rdma{{.Gres.Index}}{{end}}",
+		"dashed":"{{index .Args \"KEY-WITH-DASH\"}}"
 	}`)
 
 	out, err := Render(raw, BuildVars("dev0", "7", map[string]string{
@@ -99,13 +100,10 @@ func TestRenderAllowsBuiltInTemplateSyntax(t *testing.T) {
 	}
 }
 
-func TestRenderMissingDirectKeyUsesZeroValue(t *testing.T) {
+func TestRenderMissingDirectArgKeyUsesZeroValue(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`{
-		"missingArg":"{{.ARGS.MISSING}}",
-		"missingGRES":"{{.GRES.missing}}"
-	}`)
+	raw := []byte(`{"missingArg":"{{.Args.MISSING}}"}`)
 
 	out, err := Render(raw, BuildVars("dev0", "7", map[string]string{}))
 	if err != nil {
@@ -119,15 +117,12 @@ func TestRenderMissingDirectKeyUsesZeroValue(t *testing.T) {
 	if got["missingArg"] != "" {
 		t.Fatalf("missingArg = %q, want empty string", got["missingArg"])
 	}
-	if got["missingGRES"] != "" {
-		t.Fatalf("missingGRES = %q, want empty string", got["missingGRES"])
-	}
 }
 
 func TestRenderMissingIndexedKeyUsesZeroValue(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`{"missingDashed":"{{index .ARGS \"MISSING-DASH\"}}"}`)
+	raw := []byte(`{"missingDashed":"{{index .Args \"MISSING-DASH\"}}"}`)
 	out, err := Render(raw, BuildVars("", "", map[string]string{}))
 	if err != nil {
 		t.Fatalf("Render() error = %v", err)
@@ -142,10 +137,20 @@ func TestRenderMissingIndexedKeyUsesZeroValue(t *testing.T) {
 	}
 }
 
+func TestRenderUnknownGresFieldErrors(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"missingGres":"{{.Gres.Missing}}"}`)
+	_, err := Render(raw, BuildVars("dev0", "7", map[string]string{}))
+	if err == nil {
+		t.Fatal("expected error for unknown .Gres field")
+	}
+}
+
 func TestRenderKeepsOutputValidJSON(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`{"note":"{{.ARGS.TEXT}}"}`)
+	raw := []byte(`{"note":"{{.Args.TEXT}}"}`)
 	out, err := Render(raw, BuildVars("", "", map[string]string{
 		"TEXT": `a"b\c`,
 	}))
@@ -162,10 +167,53 @@ func TestRenderKeepsOutputValidJSON(t *testing.T) {
 	}
 }
 
+func TestRenderPreservesLargeJSONNumbers(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"type":"plugin",
+		"big":9007199254740993,
+		"nested":{"huge":18446744073709551615}
+	}`)
+
+	out, err := Render(raw, BuildVars("", "", nil))
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(out))
+	dec.UseNumber()
+
+	var got map[string]any
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+
+	big, ok := got["big"].(json.Number)
+	if !ok {
+		t.Fatalf("big has type %T, want json.Number", got["big"])
+	}
+	if big.String() != "9007199254740993" {
+		t.Fatalf("big = %q, want %q", big.String(), "9007199254740993")
+	}
+
+	nested, ok := got["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested has type %T, want map[string]any", got["nested"])
+	}
+	huge, ok := nested["huge"].(json.Number)
+	if !ok {
+		t.Fatalf("nested.huge has type %T, want json.Number", nested["huge"])
+	}
+	if huge.String() != "18446744073709551615" {
+		t.Fatalf("nested.huge = %q, want %q", huge.String(), "18446744073709551615")
+	}
+}
+
 func TestRenderBadTemplateErrors(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`{"note":"{{if .GRES.device}}"}`)
+	raw := []byte(`{"note":"{{if .Gres.Device}}"}`)
 	_, err := Render(raw, BuildVars("dev0", "0", nil))
 	if err == nil {
 		t.Fatal("expected parse error")

--- a/tool/meta-cni/pkg/types/config.go
+++ b/tool/meta-cni/pkg/types/config.go
@@ -47,11 +47,10 @@ func (p *Pipeline) IsTemplate() bool {
 
 // DelegateEntry describes a child plugin invoked by this meta plugin.
 type DelegateEntry struct {
-	Name            string            `json:"name,omitempty"`
-	Type            string            `json:"type,omitempty"`
-	Conf            json.RawMessage   `json:"conf,omitempty"`
-	RuntimeOverride *RuntimeOverride  `json:"runtimeOverride,omitempty"`
-	ConfFromArgs    map[string]string `json:"confFromArgs,omitempty"`
+	Name            string           `json:"name,omitempty"`
+	Type            string           `json:"type,omitempty"`
+	Conf            json.RawMessage  `json:"conf,omitempty"`
+	RuntimeOverride *RuntimeOverride `json:"runtimeOverride,omitempty"`
 }
 
 // RuntimeOverride alters the runtime information passed to child plugins.
@@ -304,6 +303,6 @@ func (d *DelegateEntry) Identifier() string {
 
 // String returns a human-readable representation of DelegateEntry for logging.
 func (d DelegateEntry) String() string {
-	return fmt.Sprintf("{Name:%s Type:%s Conf:%s RuntimeOverride:%+v ConfFromArgs:%v}",
-		d.Name, d.Type, string(d.Conf), d.RuntimeOverride, d.ConfFromArgs)
+	return fmt.Sprintf("{Name:%s Type:%s Conf:%s RuntimeOverride:%+v}",
+		d.Name, d.Type, string(d.Conf), d.RuntimeOverride)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration templating docs and examples to use inline Go-template syntax, new runtime variables (.Gres.*, .Args.*), and clarified rendering rules; example pipelines now include the additional RDMA delegate stage.

* **Bug Fixes**
  * Template pipelines now fail when required GRES annotations are missing (stricter validation).
  * Normalized log output to ensure messages end with a newline.

* **Refactor**
  * Replaced legacy conf-from-args behavior with JSON-aware inline template rendering.

* **Tests**
  * Added tests covering template rendering, missing-arg behavior, and error cases.

* **Chores**
  * Added .worktrees/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->