### PR TITLE
feat: Include CNI plugin and configs in RPM/DEB packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,6 +111,30 @@ nfpms:
         file_info:
           mode: 0644
 
+      # CNI plugin binaries
+      - src: build/tool/meta-cni
+        dst: /opt/cni/bin/crane-meta
+        file_info:
+          mode: 0755
+      - src: build/tool/dns-register
+        dst: /opt/cni/bin/dns-register
+        file_info:
+          mode: 0755
+
+      # CNI plugin configurations (reference only, user must copy to /etc/cni/net.d/)
+      - src: tool/meta-cni/config/00-crane-calico.conf
+        dst: /usr/share/doc/cranesched-frontend/cni/00-crane-calico.conf
+        file_info:
+          mode: 0644
+      - src: tool/meta-cni/config/00-crane-calico-sriov.conf
+        dst: /usr/share/doc/cranesched-frontend/cni/00-crane-calico-sriov.conf
+        file_info:
+          mode: 0644
+      - src: tool/meta-cni/config/00-meta.example.conf
+        dst: /usr/share/doc/cranesched-frontend/cni/00-meta.example.conf
+        file_info:
+          mode: 0644
+
       # Documentation
       - src: LICENSE
         dst: /usr/share/doc/cranesched-frontend/LICENSE

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -123,15 +123,15 @@ nfpms:
 
       # CNI plugin configurations (reference only, user must copy to /etc/cni/net.d/)
       - src: tool/meta-cni/config/00-crane-calico.conf
-        dst: /usr/share/doc/cranesched-frontend/cni/00-crane-calico.conf
+        dst: /usr/share/doc/crane/cni/00-crane-calico.conf
         file_info:
           mode: 0644
       - src: tool/meta-cni/config/00-crane-calico-sriov.conf
-        dst: /usr/share/doc/cranesched-frontend/cni/00-crane-calico-sriov.conf
+        dst: /usr/share/doc/crane/cni/00-crane-calico-sriov.conf
         file_info:
           mode: 0644
       - src: tool/meta-cni/config/00-meta.example.conf
-        dst: /usr/share/doc/cranesched-frontend/cni/00-meta.example.conf
+        dst: /usr/share/doc/crane/cni/00-meta.example.conf
         file_info:
           mode: 0644
 

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ check-goreleaser:
 package: check-goreleaser
 ifneq ($(SKIP_REBUILD),true)
 	@echo "- Rebuilding binaries and plugins for packaging..."
-	@$(MAKE) STRIP=true protos build plugin
+	@$(MAKE) STRIP=true protos build plugin tool
 else
 	@echo "- Skipping rebuild (SKIP_REBUILD=true). Using existing build artifacts."
 endif


### PR DESCRIPTION
## Summary

- Build CNI tools (`meta-cni`, `dns-register`) before packaging by adding `tool` to `make package` target
- Include CNI plugin binaries in `cranesched-frontend` package:
  - `meta-cni` → `/opt/cni/bin/crane-meta`
  - `dns-register` → `/opt/cni/bin/dns-register`
- Include CNI configuration files as reference docs in ` /usr/share/doc/crane/cni/`:
  - `00-crane-calico.conf`
  - `00-crane-calico-sriov.conf`
  - `00-meta.example.conf`

Users must manually copy the appropriate config to `/etc/cni/net.d/` and edit environment-specific values (etcd endpoints, subnets, etc.) after installation.

🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package configuration updated to include container networking plugin artifacts and accompanying reference configuration files for distribution and documentation of CNI integrations.
  * Build packaging process enhanced to automatically include additional tool components during packaging to produce more complete distributable artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PKUHPC/CraneSched-FrontEnd/pull/433)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PKUHPC/CraneSched-FrontEnd/pull/433)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->