### PR TITLE
feat: Support detaching from container

### DIFF
--- a/internal/ccon/attach.go
+++ b/internal/ccon/attach.go
@@ -122,7 +122,7 @@ func attachExecute(cmd *cobra.Command, args []string) error {
 
 		// Start streaming
 		ctx := context.Background()
-		if err := StreamWithURL(ctx, reply.Url, streamOpts); err != nil {
+		if err := streamWithURL(ctx, reply.Url, streamOpts, jobID, stepID); err != nil {
 			return util.WrapCraneErr(util.ErrorBackend, "Stream connection lost. Please check container status with 'ccon ps' or reattach with 'ccon attach': %v", err)
 		}
 	}

--- a/internal/ccon/cmd.go
+++ b/internal/ccon/cmd.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const detachKeysHelp = "Detach key: in an interactive TTY session, press Ctrl-P + Ctrl-Q to detach without stopping the container."
+
 func ParseCmdArgs() {
 	cobra.EnableTraverseRunHooks = true
 	util.RunEWrapperForLeafCommand(RootCmd)
@@ -73,6 +75,7 @@ var (
 	RunCmd = &cobra.Command{
 		Use:              "run [flags] IMAGE [COMMAND] [ARG...]",
 		Short:            "Create and run a new container",
+		Long:             "Create and run a new container.\n\n" + detachKeysHelp,
 		PersistentPreRun: initConfigAndStub,
 		RunE:             runExecute,
 	}
@@ -129,6 +132,7 @@ var (
 	AttachCmd = &cobra.Command{
 		Use:              "attach [flags] CONTAINER",
 		Short:            "Attach local standard input, output, and error streams to a running container",
+		Long:             "Attach local standard input, output, and error streams to a running container.\n\n" + detachKeysHelp,
 		PersistentPreRun: initConfigAndStub,
 		RunE:             attachExecute,
 	}
@@ -136,6 +140,7 @@ var (
 	ExecCmd = &cobra.Command{
 		Use:              "exec [flags] CONTAINER COMMAND [ARG...]",
 		Short:            "Execute a command in a running container",
+		Long:             "Execute a command in a running container.\n\n" + detachKeysHelp,
 		PersistentPreRun: initConfigAndStub,
 		RunE:             execExecute,
 	}

--- a/internal/ccon/cmd_test.go
+++ b/internal/ccon/cmd_test.go
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2025 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ccon
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestInteractiveCommandsMentionDetachKeysInHelp(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "run", cmd: RunCmd},
+		{name: "attach", cmd: AttachCmd},
+		{name: "exec", cmd: ExecCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			tt.cmd.SetOut(&out)
+			tt.cmd.SetErr(&out)
+
+			if err := tt.cmd.Help(); err != nil {
+				t.Fatalf("Help() error: %v", err)
+			}
+			if got := out.String(); !strings.Contains(got, "Ctrl-P + Ctrl-Q") {
+				t.Fatalf("help output does not mention detach keys; output:\n%s", got)
+			}
+		})
+	}
+}

--- a/internal/ccon/exec.go
+++ b/internal/ccon/exec.go
@@ -122,7 +122,7 @@ func execExecute(cmd *cobra.Command, args []string) error {
 
 		// Start streaming
 		ctx := context.Background()
-		if err := StreamWithURL(ctx, reply.Url, streamOpts); err != nil {
+		if err := streamWithURL(ctx, reply.Url, streamOpts, jobID, stepID); err != nil {
 			return util.WrapCraneErr(util.ErrorBackend, "Stream connection lost. Please check container status with 'ccon ps' or reattach with 'ccon attach': %v", err)
 		}
 	}

--- a/internal/ccon/run.go
+++ b/internal/ccon/run.go
@@ -942,7 +942,7 @@ func attachAfterRun(f *Flags, reply protoreflect.ProtoMessage) error {
 
 		if reply.GetOk() {
 			// Case 1: Success - execute expected operation
-			return StreamWithURL(ctx, reply.GetUrl(), streamOpt)
+			return streamWithURL(ctx, reply.GetUrl(), streamOpt, jobId, stepId)
 		}
 
 		switch reply.GetStatus().GetCode() {

--- a/internal/ccon/stream.go
+++ b/internal/ccon/stream.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -36,6 +37,145 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
+
+const (
+	DetachFirstKey   byte = 0x10 // Ctrl-P
+	DetachSecondKey  byte = 0x11 // Ctrl-Q
+	DetachKeyTimeout      = 1 * time.Second
+)
+
+// DetachDetector wraps an io.Reader, scanning for a Ctrl-P then Ctrl-Q sequence
+// within DetachKeyTimeout. On match, Detached() closes and subsequent Read
+// calls return io.EOF.
+//
+// It is intended to be placed between os.Stdin and remotecommand's
+// StreamOptions.Stdin so that the streaming goroutine observes an EOF on
+// stdin and shuts down the SPDY/WS stream, leaving the remote container
+// running.
+//
+// Read is called serially by remotecommand's stdin goroutine, but Detached()
+// may be selected from a different goroutine; the mutex protects the
+// detached/detachCh fields from a data race.
+type DetachDetector struct {
+	inner  io.Reader
+	first  byte
+	second byte
+
+	mu       sync.Mutex
+	armed    bool
+	armedAt  time.Time
+	detached bool
+	detachCh chan struct{}
+}
+
+func NewDetachDetector(inner io.Reader) *DetachDetector {
+	return &DetachDetector{
+		inner:    inner,
+		first:    DetachFirstKey,
+		second:   DetachSecondKey,
+		detachCh: make(chan struct{}),
+	}
+}
+
+// Detached returns a channel that is closed when the user has pressed
+// Ctrl-P then Ctrl-Q within DetachKeyTimeout.
+func (d *DetachDetector) Detached() <-chan struct{} { return d.detachCh }
+
+func (d *DetachDetector) IsDetached() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.detached
+}
+
+func (d *DetachDetector) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	d.mu.Lock()
+	if d.detached {
+		d.mu.Unlock()
+		return 0, io.EOF
+	}
+	d.mu.Unlock()
+
+	n, err := d.inner.Read(p)
+	if n <= 0 {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if d.detached {
+			return 0, io.EOF
+		}
+		if err == io.EOF && d.armed {
+			d.armed = false
+			p[0] = d.first
+			return 1, nil
+		}
+		return n, err
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.detached {
+		return 0, io.EOF
+	}
+
+	out := make([]byte, 0, n)
+	for i := 0; i < n; i++ {
+		b := p[i]
+
+		// If armed has timed out, flush the held Ctrl-P into the output
+		// before processing this byte. This implements the "timeout
+		// auto-flush" semantics required for the cross-Read case.
+		if d.armed && time.Since(d.armedAt) > DetachKeyTimeout {
+			out = append(out, d.first)
+			d.armed = false
+		}
+
+		if !d.armed {
+			if b == d.first {
+				d.armed = true
+				d.armedAt = time.Now()
+				continue
+			}
+			out = append(out, b)
+			continue
+		}
+
+		// armed == true
+		switch b {
+		case d.second:
+			d.detached = true
+			close(d.detachCh)
+			// Flush any pending output bytes that were accumulated
+			// earlier in this same Read (e.g. the "a" in "aPQ"), then
+			// signal EOF. If there is nothing to flush, return EOF
+			// directly.
+			nOut := copy(p, out)
+			if nOut == 0 {
+				return 0, io.EOF
+			}
+			return nOut, nil
+		case d.first:
+			// "P P" re-arms with a fresh timestamp; the first P is
+			// consumed as part of the re-arm, not forwarded.
+			d.armed = true
+			d.armedAt = time.Now()
+		default:
+			// Armed P was not followed by Q within the sequence; emit
+			// the held P together with this byte and disarm.
+			out = append(out, d.first)
+			d.armed = false
+			out = append(out, b)
+		}
+	}
+	nOut := copy(p, out)
+	return nOut, nil
+}
+
+func shouldEnableDetach(opts StreamOptions, stdinIsTerminal bool) bool {
+	return opts.Stdin && opts.Tty && stdinIsTerminal
+}
 
 type StreamOptions struct {
 	Stdin     bool
@@ -119,17 +259,45 @@ func (t *TerminalSizeQueue) getTerminalSize() *remotecommand.TerminalSize {
 	}
 }
 
-func StreamWithURL(ctx context.Context, streamURL string, opts StreamOptions) error {
-	return streamWithRetry(ctx, streamURL, opts, 3)
-}
-
-func streamWithRetry(ctx context.Context, streamURL string, opts StreamOptions, maxRetries int) error {
+// streamWithURL is the single ccon streaming entry point. It preserves retry
+// for ordinary stream failures and exits without retry after Ctrl-P-Q detach.
+func streamWithURL(ctx context.Context, streamURL string,
+	opts StreamOptions, jobID, stepID uint32) error {
 	var lastErr error
+	const maxRetries = 3
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		log.Debugf("Stream attempt %d/%d for URL: %s", attempt, maxRetries, streamURL)
 
-		err := doStream(ctx, streamURL, opts)
+		streamCtx := ctx
+		cancel := func() {}
+		var stdin io.Reader
+		var detector *DetachDetector
+		if opts.Stdin {
+			stdin = os.Stdin
+			if shouldEnableDetach(opts, term.IsTerminal(int(os.Stdin.Fd()))) {
+				streamCtx, cancel = context.WithCancel(ctx)
+				detector = NewDetachDetector(os.Stdin)
+				stdin = detector
+				go func() {
+					select {
+					case <-detector.Detached():
+						cancel()
+					case <-streamCtx.Done():
+					}
+				}()
+			}
+		}
+
+		err := streamOnce(streamCtx, streamURL, opts, stdin)
+		cancel()
+		if detector != nil && detector.IsDetached() {
+			fmt.Fprintf(os.Stderr,
+				"\nDetached from container %d.%d. The container is still running; "+
+					"re-attach with: ccon attach %d.%d\n",
+				jobID, stepID, jobID, stepID)
+			return nil
+		}
 		if err == nil || errors.Is(err, context.Canceled) {
 			return nil
 		}
@@ -150,7 +318,9 @@ func streamWithRetry(ctx context.Context, streamURL string, opts StreamOptions, 
 	return fmt.Errorf("stream failed after %d attempts, last error: %w", maxRetries, lastErr)
 }
 
-func doStream(ctx context.Context, streamURL string, opts StreamOptions) error {
+func streamOnce(ctx context.Context, streamURL string,
+	opts StreamOptions, stdin io.Reader) error {
+
 	parsedURL, err := url.Parse(streamURL)
 	if err != nil {
 		return fmt.Errorf("invalid stream URL: %w", err)
@@ -163,13 +333,9 @@ func doStream(ctx context.Context, streamURL string, opts StreamOptions) error {
 		},
 	}
 
-	var stdin io.Reader
 	var stdout, stderr io.Writer
 	var tty bool
 
-	if opts.Stdin {
-		stdin = os.Stdin
-	}
 	if opts.Stdout {
 		stdout = os.Stdout
 	}

--- a/internal/ccon/stream.go
+++ b/internal/ccon/stream.go
@@ -157,8 +157,9 @@ func (d *DetachDetector) Read(p []byte) (int, error) {
 			}
 			return nOut, nil
 		case d.first:
-			// "P P" re-arms with a fresh timestamp; the first P is
-			// consumed as part of the re-arm, not forwarded.
+			// "P P" means the first held P did not start a detach sequence.
+			// Forward it and keep the second P armed for the next byte.
+			out = append(out, d.first)
 			d.armed = true
 			d.armedAt = time.Now()
 		default:

--- a/internal/ccon/stream_test.go
+++ b/internal/ccon/stream_test.go
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2025 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ccon
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestDetachOnPQ_SameRead verifies the canonical P-then-Q sequence delivered
+// in a single Read triggers detach and the leading bytes are forwarded.
+func TestDetachOnPQ_SameRead(t *testing.T) {
+	inner := bytes.NewReader([]byte{'a', DetachFirstKey, DetachSecondKey, 'b'})
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if got := string(buf[:n]); got != "a" {
+		t.Fatalf("forwarded bytes = %q, want %q", got, "a")
+	}
+	select {
+	case <-d.Detached():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Detached() did not close after P-Q")
+	}
+}
+
+// TestDetachAcrossReads verifies the state machine survives the cross-Read
+// case: a raw TTY typically returns Ctrl-P in one Read and Ctrl-Q in the
+// next, separated by a short interval within DetachKeyTimeout.
+func TestDetachAcrossReads(t *testing.T) {
+	// First call yields the prefix including Ctrl-P.
+	inner := &stepReader{
+		chunks: [][]byte{
+			{'a', DetachFirstKey},
+			{DetachSecondKey, 'b'},
+		},
+	}
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("first Read error: %v", err)
+	}
+	if got := string(buf[:n]); got != "a" {
+		t.Fatalf("first forwarded = %q, want %q", got, "a")
+	}
+
+	// Second Read should observe the held P timed out... but we are still
+	// within DetachKeyTimeout, so it stays armed and triggers on Q.
+	n, err = d.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("second Read err = %v, want io.EOF", err)
+	}
+	if n != 0 {
+		t.Fatalf("second Read n = %d, want 0", n)
+	}
+	select {
+	case <-d.Detached():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Detached() did not close across reads")
+	}
+}
+
+// TestTimeoutFlushesCtrlP verifies an armed P that does not see Q within
+// DetachKeyTimeout is re-emitted on the next Read. This protects ordinary
+// Ctrl-P usage (e.g. readline history) when no Q follows.
+func TestTimeoutFlushesCtrlP(t *testing.T) {
+	inner := &stepReader{
+		chunks: [][]byte{
+			{DetachFirstKey},
+			{'x'},
+		},
+	}
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("first Read error: %v", err)
+	}
+
+	// Wait long enough for the armed P to expire.
+	time.Sleep(DetachKeyTimeout + 100*time.Millisecond)
+
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("second Read error: %v", err)
+	}
+	if got := string(buf[:n]); got != string([]byte{DetachFirstKey, 'x'}) {
+		t.Fatalf("timeout flush output = %q, want %q", got, string([]byte{DetachFirstKey, 'x'}))
+	}
+	select {
+	case <-d.Detached():
+		t.Fatal("Detached() should not have closed on a single P")
+	default:
+	}
+}
+
+// TestPendingCtrlPFlushesOnEOF verifies a held Ctrl-P is not lost when the
+// underlying input closes before a matching Ctrl-Q or timeout-triggering byte.
+func TestPendingCtrlPFlushesOnEOF(t *testing.T) {
+	inner := &stepReader{
+		chunks: [][]byte{
+			{DetachFirstKey},
+		},
+	}
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	if _, err := d.Read(buf); err != nil {
+		t.Fatalf("first Read error: %v", err)
+	}
+
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("second Read error: %v", err)
+	}
+	if got := string(buf[:n]); got != string([]byte{DetachFirstKey}) {
+		t.Fatalf("EOF flush output = %q, want %q", got, string([]byte{DetachFirstKey}))
+	}
+}
+
+// TestPostDetachEOF verifies subsequent Reads after detach return EOF
+// without consulting the inner reader.
+func TestPostDetachEOF(t *testing.T) {
+	inner := bytes.NewReader([]byte{DetachFirstKey, DetachSecondKey})
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	if _, err := d.Read(buf); err != io.EOF {
+		t.Fatalf("first Read err = %v, want io.EOF", err)
+	}
+
+	// A second call must also return EOF cleanly.
+	n, err := d.Read(buf)
+	if n != 0 || err != io.EOF {
+		t.Fatalf("post-detach Read = (%d, %v), want (0, io.EOF)", n, err)
+	}
+}
+
+func TestShouldEnableDetachRequiresStdinTTYAndTerminal(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             StreamOptions
+		stdinIsTerminal  bool
+		wantEnableDetach bool
+	}{
+		{
+			name: "interactive TTY terminal",
+			opts: StreamOptions{
+				Stdin: true,
+				Tty:   true,
+			},
+			stdinIsTerminal:  true,
+			wantEnableDetach: true,
+		},
+		{
+			name: "stdin disabled",
+			opts: StreamOptions{
+				Stdin: false,
+				Tty:   true,
+			},
+			stdinIsTerminal:  true,
+			wantEnableDetach: false,
+		},
+		{
+			name: "tty disabled",
+			opts: StreamOptions{
+				Stdin: true,
+				Tty:   false,
+			},
+			stdinIsTerminal:  true,
+			wantEnableDetach: false,
+		},
+		{
+			name: "piped stdin",
+			opts: StreamOptions{
+				Stdin: true,
+				Tty:   true,
+			},
+			stdinIsTerminal:  false,
+			wantEnableDetach: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldEnableDetach(tt.opts, tt.stdinIsTerminal); got != tt.wantEnableDetach {
+				t.Fatalf("shouldEnableDetach() = %t, want %t", got, tt.wantEnableDetach)
+			}
+		})
+	}
+}
+
+// stepReader hands out its chunks one at a time, simulating a TTY that
+// returns a small number of bytes per Read call.
+type stepReader struct {
+	chunks [][]byte
+	idx    int
+}
+
+func (s *stepReader) Read(p []byte) (int, error) {
+	if s.idx >= len(s.chunks) {
+		return 0, io.EOF
+	}
+	c := s.chunks[s.idx]
+	s.idx++
+	if len(c) > len(p) {
+		c = c[:len(p)]
+	}
+	copy(p, c)
+	return len(c), nil
+}

--- a/internal/ccon/stream_test.go
+++ b/internal/ccon/stream_test.go
@@ -142,6 +142,48 @@ func TestPendingCtrlPFlushesOnEOF(t *testing.T) {
 	}
 }
 
+// TestRepeatedCtrlPForwardsPreviousKey verifies a second Ctrl-P releases the
+// first held Ctrl-P and keeps the second Ctrl-P armed for the next byte.
+func TestRepeatedCtrlPForwardsPreviousKey(t *testing.T) {
+	inner := bytes.NewReader([]byte{DetachFirstKey, DetachFirstKey, 'x'})
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("Read error: %v", err)
+	}
+	if got := string(buf[:n]); got != string([]byte{DetachFirstKey, DetachFirstKey, 'x'}) {
+		t.Fatalf("forwarded bytes = %q, want %q", got, string([]byte{DetachFirstKey, DetachFirstKey, 'x'}))
+	}
+	select {
+	case <-d.Detached():
+		t.Fatal("Detached() should not close on Ctrl-P Ctrl-P x")
+	default:
+	}
+}
+
+// TestRepeatedCtrlPThenQDetaches verifies Ctrl-P Ctrl-P Ctrl-Q forwards the
+// first Ctrl-P, then treats the second Ctrl-P plus Ctrl-Q as the detach key.
+func TestRepeatedCtrlPThenQDetaches(t *testing.T) {
+	inner := bytes.NewReader([]byte{'a', DetachFirstKey, DetachFirstKey, DetachSecondKey, 'b'})
+	d := NewDetachDetector(inner)
+
+	buf := make([]byte, 16)
+	n, err := d.Read(buf)
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if got := string(buf[:n]); got != string([]byte{'a', DetachFirstKey}) {
+		t.Fatalf("forwarded bytes = %q, want %q", got, string([]byte{'a', DetachFirstKey}))
+	}
+	select {
+	case <-d.Detached():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Detached() did not close after second Ctrl-P plus Ctrl-Q")
+	}
+}
+
 // TestPostDetachEOF verifies subsequent Reads after detach return EOF
 // without consulting the inner reader.
 func TestPostDetachEOF(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive detach via the `Ctrl-P` then `Ctrl-Q` key sequence for run/attach/exec sessions, allowing users to exit the interactive stream while keeping the underlying connection alive for re-attachment.
  * Updated command help text to document the detach key sequence.
* **Tests**
  * Added a dedicated test suite covering detach detection across reads, timeout flushing behavior, EOF handling after detachment, and enablement only when stdin is an interactive terminal.
  * Added a help-text test to ensure detach keys are mentioned for relevant commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->