### PR TITLE
fix: change sge -h output

### DIFF
--- a/internal/cwrapper/sge.go
+++ b/internal/cwrapper/sge.go
@@ -59,6 +59,11 @@ func (w SGEWrapper) HasCommand(cmd string) bool {
 }
 
 func (w SGEWrapper) Preprocess() error {
+	subCommand := ""
+	if len(os.Args) > 1 {
+		subCommand = os.Args[1]
+	}
+
 	for i, v := range os.Args {
 		// Skip program name and subcommand
 		if i <= 1 {
@@ -73,6 +78,11 @@ func (w SGEWrapper) Preprocess() error {
 		case "-?":
 			os.Args[i] = "--help"
 			continue
+		case "-h":
+			if sgeHelpShortAliasEnabled(subCommand) {
+				os.Args[i] = "--help"
+				continue
+			}
 		}
 
 		if len(v) >= 2 && v[0] == '-' && v[1] != '-' {
@@ -81,6 +91,10 @@ func (w SGEWrapper) Preprocess() error {
 	}
 
 	return nil
+}
+
+func sgeHelpShortAliasEnabled(subCommand string) bool {
+	return slices.Contains([]string{"qacct", "qdel", "qstat"}, subCommand)
 }
 
 var (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help command handling for selected SGE subcommands.
  * The `-h` option now correctly acts as shorthand for `--help` only where supported, while preserving existing help aliases elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->