### PR TITLE
fix: read standalone plugin config

### DIFF
--- a/internal/cacctmgr/cacctmgr.go
+++ b/internal/cacctmgr/cacctmgr.go
@@ -974,13 +974,13 @@ func UnblockAccountOrUser(value string, entityType protos.EntityType, account st
 }
 
 // GetPlugindClient connects to cplugind for querying event data via RPC
-func GetPlugindClient(config *util.Config) (protos.PluginQueryServiceClient, *grpc.ClientConn, error) {
-	if !config.Plugin.Enabled {
+func GetPlugindClient(config *util.Config, pluginConfig *util.PluginConfig) (protos.PluginQueryServiceClient, *grpc.ClientConn, error) {
+	if !pluginConfig.Enabled {
 		return nil, nil, util.NewCraneErr(util.ErrorCmdArg, "Plugin is not enabled")
 	}
 
-	addr := config.Plugin.ListenAddress
-	port := config.Plugin.ListenPort
+	addr := pluginConfig.ListenAddress
+	port := pluginConfig.ListenPort
 	if addr == "" || port == "" {
 		return nil, nil, util.NewCraneErr(util.ErrorCmdArg,
 			"PlugindListenAddress and PlugindListenPort must be configured")
@@ -1104,8 +1104,14 @@ func QueryEventInfoByNodes(nodeRegex string, maxLines int) error {
 	}
 	// If no nodes specified, nodeNames will be empty and query all nodes
 
+	pluginConfig, err := util.ParsePluginConfig(FlagPluginConfigFilePath)
+	if err != nil {
+		return util.NewCraneErr(util.ErrorCmdArg,
+			fmt.Sprintf("Failed to parse plugin config from %s: %v", FlagPluginConfigFilePath, err))
+	}
+
 	// Connect to cplugind
-	pluginClient, pluginConn, err := GetPlugindClient(config)
+	pluginClient, pluginConn, err := GetPlugindClient(config, pluginConfig)
 	if err != nil {
 		return util.WrapCraneErr(util.ErrorNetwork, "Failed to connect to cplugind: %v", err)
 	}

--- a/internal/cacctmgr/cmd.go
+++ b/internal/cacctmgr/cmd.go
@@ -66,10 +66,11 @@ var (
 	FlagUserPartitions  []string
 	FlagUserQosList     []string
 
-	FlagForce          bool
-	FlagFull           bool
-	FlagJson           bool
-	FlagConfigFilePath string = util.DefaultConfigPath
+	FlagForce                bool
+	FlagFull                 bool
+	FlagJson                 bool
+	FlagConfigFilePath       string = util.DefaultConfigPath
+	FlagPluginConfigFilePath string = util.DefaultPluginConfigPath
 
 	// These flags are implemented,
 	// but not added to any cmd!

--- a/internal/cacctmgr/help.go
+++ b/internal/cacctmgr/help.go
@@ -303,6 +303,7 @@ func showHelp() {
   GLOBAL OPTIONS:
 	--help, -h              Display this help message
 	--config, -C            Specify config file path (default: /etc/crane/config.yaml)
+	--plugin-config, -p     Specify plugin config file path (default: /etc/crane/plugin.yaml)
 	--json, -J              Format output as JSON
 	--version, -v           Display program version
 	--force, -f             Force operation without confirmation

--- a/internal/cacctmgr/parser.go
+++ b/internal/cacctmgr/parser.go
@@ -393,6 +393,13 @@ func preParseGlobalFlags(args []string) []string {
 				FlagConfigFilePath = args[i+1]
 				i++
 			}
+		case "-p", "--plugin-config":
+			if hasValueInSameArg {
+				FlagPluginConfigFilePath = flagValue
+			} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				FlagPluginConfigFilePath = args[i+1]
+				i++
+			}
 		case "--force", "-f":
 			FlagForce = true
 		case "--partition-limit", "-P":

--- a/internal/ceff/ceff.go
+++ b/internal/ceff/ceff.go
@@ -77,13 +77,13 @@ type CeffJobInfo struct {
 var isFirstCall = true //Used for multi-job print
 
 // Connect to cplugind for querying efficiency data
-func GetPlugindClient(config *util.Config) (protos.PluginQueryServiceClient, *grpc.ClientConn, error) {
-	if !config.Plugin.Enabled {
+func GetPlugindClient(config *util.Config, pluginConfig *util.PluginConfig) (protos.PluginQueryServiceClient, *grpc.ClientConn, error) {
+	if !pluginConfig.Enabled {
 		return nil, nil, util.NewCraneErr(util.ErrorCmdArg, "Plugin is not enabled")
 	}
 
-	addr := config.Plugin.ListenAddress
-	port := config.Plugin.ListenPort
+	addr := pluginConfig.ListenAddress
+	port := pluginConfig.ListenPort
 	if addr == "" || port == "" {
 		return nil, nil, util.NewCraneErr(util.ErrorCmdArg,
 			"PlugindListenAddress and PlugindListenPort must be configured for ceff")

--- a/internal/ceff/cmd.go
+++ b/internal/ceff/cmd.go
@@ -20,13 +20,15 @@ package ceff
 
 import (
 	"CraneFrontEnd/internal/util"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	FlagConfigFilePath string
-	FlagJson           bool
+	FlagConfigFilePath       string
+	FlagPluginConfigFilePath string
+	FlagJson                 bool
 
 	RootCmd = &cobra.Command{
 		Use:     "ceff [flags] [job_id, ...]",
@@ -37,8 +39,13 @@ var (
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			util.DetectNetworkProxy()
 			config := util.ParseConfig(FlagConfigFilePath)
+			pluginConfig, err := util.ParsePluginConfig(FlagPluginConfigFilePath)
+			if err != nil {
+				return util.NewCraneErr(util.ErrorCmdArg,
+					fmt.Sprintf("Failed to parse plugin config from %s: %v", FlagPluginConfigFilePath, err))
+			}
 			stub = util.GetStubToCtldByConfig(config)
-			client, conn, err := GetPlugindClient(config)
+			client, conn, err := GetPlugindClient(config, pluginConfig)
 			if err != nil {
 				return err
 			}
@@ -70,6 +77,8 @@ func init() {
 	RootCmd.SetVersionTemplate(util.VersionTemplate())
 	RootCmd.PersistentFlags().StringVarP(&FlagConfigFilePath, "config", "C",
 		util.DefaultConfigPath, "Path to configuration file")
+	RootCmd.PersistentFlags().StringVarP(&FlagPluginConfigFilePath, "plugin-config", "p",
+		util.DefaultPluginConfigPath, "Path to plugin configuration file")
 	RootCmd.PersistentFlags().BoolVar(&FlagJson, "json", false, "Output in JSON format")
 	util.InitCraneLogger()
 }

--- a/internal/cplugind/loader.go
+++ b/internal/cplugind/loader.go
@@ -22,12 +22,10 @@ import (
 	"CraneFrontEnd/api"
 	"CraneFrontEnd/internal/util"
 	"fmt"
-	"os"
 	"path/filepath"
 	"plugin"
 
 	log "github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v3"
 )
 
 type PluginLoaded struct {
@@ -43,15 +41,12 @@ var (
 )
 
 func ParsePluginConfig(basedir string, path string) error {
-	config, err := os.ReadFile(path)
+	config, err := util.ParsePluginConfig(path)
 	if err != nil {
 		return err
 	}
 
-	// Parse plugin config directly from standalone plugin.yaml file
-	if err = yaml.Unmarshal(config, &gPluginConfig); err != nil {
-		return err
-	}
+	gPluginConfig = *config
 	if gPluginConfig.LogLevel == "" {
 		gPluginConfig.LogLevel = "info"
 	}

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -111,6 +111,20 @@ func ParseConfig(configFilePath string) *Config {
 	return config
 }
 
+func ParsePluginConfig(configFilePath string) (*PluginConfig, error) {
+	confFile, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &PluginConfig{}
+	if err = yaml.Unmarshal(confFile, config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
 func ParseMemStringAsByte(mem string) (uint64, error) {
 	re := regexp.MustCompile(`^([0-9]+(\.?[0-9]*))([MmGgKkB]?)$`)
 	result := re.FindAllStringSubmatch(mem, -1)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -40,7 +40,6 @@ type Config struct {
 	JobLifecycleHook JobLifecycleHookConfig `yaml:"JobLifecycleHook"`
 
 	Container ContainerConfig `yaml:"Container"`
-	Plugin    PluginConfig    `yaml:"Plugin"`
 	Cfored    CforedConfig    `yaml:"Cfored"`
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--plugin-config` / `-p` options to specify a separate plugin configuration file.
  * Plugin settings can now be loaded from a dedicated configuration file, including enablement, address, and port.
* **Bug Fixes**
  * Improved validation and error reporting when plugin configuration is disabled, missing, or invalid.
  * Updated plugin connections to consistently use the selected plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->