### PR TITLE
fix: register cfored with short hostname

### DIFF
--- a/internal/cfored/cfored.go
+++ b/internal/cfored/cfored.go
@@ -161,7 +161,8 @@ func StartCfored(cmd *cobra.Command) {
 	if err != nil {
 		log.Fatalf("Failed to get hostname: %s", err.Error())
 	}
-	gVars.hostName = hostName
+	gVars.hostName = util.GetShortHostname(hostName)
+	log.Infof("Using %s as cfored name (system hostname: %s).", gVars.hostName, hostName)
 
 	var wgAllRoutines sync.WaitGroup
 

--- a/internal/util/os.go
+++ b/internal/util/os.go
@@ -78,6 +78,14 @@ func DetectNetworkProxy() {
 	}
 }
 
+func GetShortHostname(hostName string) string {
+	shortName, _, _ := strings.Cut(hostName, ".")
+	if shortName == "" {
+		return hostName
+	}
+	return shortName
+}
+
 func GetPidFromPort(port uint16) (int, error) {
 	// 1. Find inode number for the port
 	portHex := fmt.Sprintf("%04X", port)


### PR DESCRIPTION
## Summary

- derive the cfored registration name from the short form of the system hostname
- keep the original system hostname unchanged and log both names at startup
- share the Linux `hostname -s`-style conversion through `internal/util`

## Motivation

When a login node reports an FQDN such as `jx2-login01.hpc.pku.edu.cn`, the supervisor appends the configured TLS `DomainSuffix` again. This produces an unresolvable and certificate-mismatched target such as `jx2-login01.hpc.pku.edu.cn.crane.local`. Registering `jx2-login01` instead produces the intended `jx2-login01.crane.local` target.

## Verification

- `go test ./internal/cfored ./internal/util ./cmd/cfored`
- `go vet ./internal/cfored ./internal/util ./cmd/cfored`
- `go build -o /tmp/cfored-short-hostname ./cmd/cfored`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System identification now uses the short hostname, improving consistency across environments with fully qualified hostnames.
  * Startup logs now display both the short hostname and the full system hostname for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->