### PR TITLE
fix: revert cqueue msg

### DIFF
--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -163,7 +163,7 @@ func QueryJob() error {
 			fmt.Println(util.FmtJson.FormatReply(reply))
 		}
 		if reply.GetOk() {
-			util.PrintIncompleteQueryWarning(reply.GetHasMore(), len(reply.GetJobInfoList()))
+			printIncompleteQueryWarning(reply.GetHasMore(), len(reply.GetJobInfoList()))
 			return nil
 		} else {
 			return &util.CraneError{Code: util.ErrorBackend}
@@ -292,8 +292,18 @@ func QueryJob() error {
 
 	table.AppendBulk(tableData)
 	table.Render()
-	util.PrintIncompleteQueryWarning(reply.GetHasMore(), len(reply.GetJobInfoList()))
+	printIncompleteQueryWarning(reply.GetHasMore(), len(reply.GetJobInfoList()))
 	return nil
+}
+
+func printIncompleteQueryWarning(hasMore bool, returnedJobs int) {
+	if !hasMore {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"Query returned %d jobs, and more matching jobs exist. Use -m to adjust the number of jobs returned.\n",
+		returnedJobs)
 }
 
 // JobOrStep represents either a job (JobInfo) or a step (StepInfo)

--- a/internal/cacct/cmd.go
+++ b/internal/cacct/cmd.go
@@ -166,7 +166,7 @@ Examples:
 Note: If the format is invalid or unrecognized, the program will terminate with an error message.
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false, "Display full information (If not set, only display 30 characters per cell)")
-	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 20,
+	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.DefaultCacctMaxLines,
 		"Limit the number of jobs returned")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false, "Output in JSON format")
 	RootCmd.Flags().StringVarP(&FlagFilterNodeNames, "nodelist", "w", "",

--- a/internal/cacct/cmd.go
+++ b/internal/cacct/cmd.go
@@ -166,7 +166,7 @@ Examples:
 Note: If the format is invalid or unrecognized, the program will terminate with an error message.
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false, "Display full information (If not set, only display 30 characters per cell)")
-	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.MaxRepliedJobs,
+	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", 20,
 		"Limit the number of jobs returned")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false, "Output in JSON format")
 	RootCmd.Flags().StringVarP(&FlagFilterNodeNames, "nodelist", "w", "",

--- a/internal/cqueue/cmd.go
+++ b/internal/cqueue/cmd.go
@@ -180,7 +180,7 @@ Note: If the format is invalid or unrecognized, the program will terminate with 
 `)
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false,
 		"Display full information (If not set, only display 30 characters per cell)")
-	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.MaxRepliedJobs,
+	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.DefaultCqueueMaxLines,
 		"Limit the number of lines in the output, 0 means no limit")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")

--- a/internal/cqueue/cmd.go
+++ b/internal/cqueue/cmd.go
@@ -181,7 +181,7 @@ Note: If the format is invalid or unrecognized, the program will terminate with 
 	RootCmd.Flags().BoolVarP(&FlagFull, "full", "F", false,
 		"Display full information (If not set, only display 30 characters per cell)")
 	RootCmd.Flags().Uint32VarP(&FlagNumLimit, "max-lines", "m", util.MaxRepliedJobs,
-		"Limit the number of jobs returned")
+		"Limit the number of lines in the output, 0 means no limit")
 	RootCmd.Flags().BoolVar(&FlagJson, "json", false,
 		"Output in JSON format")
 	RootCmd.Flags().BoolVar(&FlagCount, "count", false,

--- a/internal/cqueue/cqueue.go
+++ b/internal/cqueue/cqueue.go
@@ -179,20 +179,13 @@ func Query() error {
 		return err
 	}
 
-	var outputErr error
 	if FlagJson {
-		outputErr = JsonOutput(reply)
+		return JsonOutput(reply)
 	} else if FlagStep {
-		outputErr = QueryStepsTableOutput(reply)
+		return QueryStepsTableOutput(reply)
 	} else {
-		outputErr = QueryTableOutput(reply)
+		return QueryTableOutput(reply)
 	}
-	if outputErr != nil {
-		return outputErr
-	}
-
-	util.PrintIncompleteQueryWarning(reply.GetHasMore(), len(reply.GetJobInfoList()))
-	return nil
 }
 
 func loopedQuery(iterate uint64) error {

--- a/internal/util/formatter.go
+++ b/internal/util/formatter.go
@@ -19,7 +19,6 @@
 package util
 
 import (
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -61,13 +60,3 @@ func MarshalProtoJSON(msg protoreflect.ProtoMessage) ([]byte, error) {
 }
 
 var FmtJson = FormatterJson{}
-
-func PrintIncompleteQueryWarning(hasMore bool, returnedJobs int) {
-	if !hasMore {
-		return
-	}
-
-	fmt.Fprintf(os.Stderr,
-		"Query returned %d jobs, and more matching jobs exist. Use -m to adjust the number of jobs returned.\n",
-		returnedJobs)
-}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -114,7 +114,7 @@ const (
 	DefaultWrappedJobName          = "Wrap"
 	DefaultUserNsEnabledByDefault  = true
 	GresGpuName                    = "gpu"
-	MaxRepliedJobs                 = 20
+	MaxRepliedJobs                 = 1000 // See kDefaultQueryJobNumLimit for details
 	MaxJobNameLength               = 60
 	MaxJobFileNameLength           = 127
 	MaxJobFilePathLengthForWindows = 260 - MaxJobFileNameLength

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -111,14 +111,15 @@ const (
 	DefaultCforedServerListenAddress = "0.0.0.0"
 	DefaultCforedServerListenPort    = "10012"
 
-	DefaultWrappedJobName          = "Wrap"
-	DefaultUserNsEnabledByDefault  = true
-	GresGpuName                    = "gpu"
-	MaxRepliedJobs                 = 1000 // See kDefaultQueryJobNumLimit for details
-	MaxJobNameLength               = 60
-	MaxJobFileNameLength           = 127
-	MaxJobFilePathLengthForWindows = 260 - MaxJobFileNameLength
-	MaxJobFilePathLengthForUnix    = 4096 - MaxJobFileNameLength
+	DefaultWrappedJobName                 = "Wrap"
+	DefaultUserNsEnabledByDefault         = true
+	DefaultCacctMaxLines           uint32 = 20
+	DefaultCqueueMaxLines          uint32 = 10000
+	GresGpuName                           = "gpu"
+	MaxJobNameLength                      = 60
+	MaxJobFileNameLength                  = 127
+	MaxJobFilePathLengthForWindows        = 260 - MaxJobFileNameLength
+	MaxJobFilePathLengthForUnix           = 4096 - MaxJobFileNameLength
 
 	MaxJobTimeLimit = 315576000000 // 10000 years
 	MaxJobTimeStamp = 253402300799 // 9999-12-31 23:59:59


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate default output limits for accounting and queue commands.
  * Queue output now defaults to 10,000 lines, with `0` allowing unlimited output.
  * Accounting output now defaults to 20 lines.

* **Bug Fixes**
  * Improved handling of incomplete query results and output errors.
  * Updated queue option descriptions to accurately reflect line limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->