### PR TITLE
fix: use configured FQDN for TLS connections

### DIFF
--- a/internal/cacctmgr/cacctmgr.go
+++ b/internal/cacctmgr/cacctmgr.go
@@ -50,6 +50,7 @@ var (
 
 type ServerAddr struct {
 	ControlMachine      string `yaml:"ControlMachine"`
+	ControlMachineAddr  string `yaml:"ControlMachineAddr"`
 	CraneCtldListenPort string `yaml:"CraneCtldListenPort"`
 }
 

--- a/internal/cfored/cfored.go
+++ b/internal/cfored/cfored.go
@@ -161,7 +161,11 @@ func StartCfored(cmd *cobra.Command) {
 	if err != nil {
 		log.Fatalf("Failed to get hostname: %s", err.Error())
 	}
-	gVars.hostName = hostName
+	gVars.hostName = util.GetShortHostname(hostName)
+	if FlagHostname != "" {
+		gVars.hostName = FlagHostname
+	}
+	log.Infof("Using %s as cfored name (system hostname: %s).", gVars.hostName, hostName)
 
 	var wgAllRoutines sync.WaitGroup
 

--- a/internal/cfored/cfored.go
+++ b/internal/cfored/cfored.go
@@ -161,7 +161,7 @@ func StartCfored(cmd *cobra.Command) {
 	if err != nil {
 		log.Fatalf("Failed to get hostname: %s", err.Error())
 	}
-	gVars.hostName = util.GetShortHostname(hostName)
+	gVars.hostName = hostName
 	if FlagHostname != "" {
 		gVars.hostName = FlagHostname
 	}

--- a/internal/cfored/cmd.go
+++ b/internal/cfored/cmd.go
@@ -32,6 +32,7 @@ import (
 var (
 	FlagConfigFilePath string
 	FlagDebugLevel     string
+	FlagHostname       string
 	FlagReload         bool
 )
 
@@ -54,6 +55,8 @@ func ParseCmdArgs() {
 		util.DefaultConfigPath, "Path to configuration file")
 	rootCmd.PersistentFlags().StringVarP(&FlagDebugLevel, "debug-level", "D",
 		"info", "Available debug level: trace,debug,info")
+	rootCmd.PersistentFlags().StringVar(&FlagHostname, "hostname", "",
+		"Hostname used to register cfored")
 	rootCmd.PersistentFlags().BoolVar(&FlagReload, "reload", false, "Reload configuration")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/util/grpc.go
+++ b/internal/util/grpc.go
@@ -194,7 +194,7 @@ func GetStubToCtldByConfig(config *Config) protos.CraneCtldClient {
 	var stub protos.CraneCtldClient
 
 	if config.TlsConfig.Enabled {
-		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachineConnectAddr(), config.CraneCtldListenPort)
 
 		if config.TlsConfig.UserTlsCertPath == "" {
 			home, err := os.UserHomeDir()
@@ -235,7 +235,7 @@ func GetStubToCtldByConfig(config *Config) protos.CraneCtldClient {
 
 		stub = protos.NewCraneCtldClient(conn)
 	} else {
-		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachineConnectAddr(), config.CraneCtldListenPort)
 
 		conn, err := grpc.NewClient(serverAddr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -261,7 +261,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 	var stub protos.CraneCtldForInternalClient
 
 	if config.TlsConfig.Enabled {
-		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldForInternalListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachineConnectAddr(), config.CraneCtldForInternalListenPort)
 
 		ServerCertContent, err := os.ReadFile(config.TlsConfig.InternalCertFilePath)
 		if err != nil {
@@ -296,6 +296,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 		creds := credentials.NewTLS(&tls.Config{
 			Certificates:       []tls.Certificate{tlsKeyPair},
 			RootCAs:            caPool,
+			ServerName:         config.ControlMachine,
 			InsecureSkipVerify: false,
 			// NextProtos is a list of supported application level protocols, in
 			// order of preference.
@@ -314,7 +315,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 
 		stub = protos.NewCraneCtldForInternalClient(conn)
 	} else {
-		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldForInternalListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachineConnectAddr(), config.CraneCtldForInternalListenPort)
 
 		conn, err = grpc.NewClient(serverAddr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -376,6 +377,7 @@ func UpdateTLSConfig(config *Config) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caPool,
+		ServerName:   "*." + config.TlsConfig.DomainSuffix,
 		MinVersion:   tls.VersionTLS13,
 	}
 

--- a/internal/util/grpc.go
+++ b/internal/util/grpc.go
@@ -194,8 +194,7 @@ func GetStubToCtldByConfig(config *Config) protos.CraneCtldClient {
 	var stub protos.CraneCtldClient
 
 	if config.TlsConfig.Enabled {
-		serverAddr = fmt.Sprintf("%s.%s:%s",
-			config.ControlMachine, config.TlsConfig.DomainSuffix, config.CraneCtldListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
 
 		if config.TlsConfig.UserTlsCertPath == "" {
 			home, err := os.UserHomeDir()
@@ -262,8 +261,7 @@ func GetStubToCtldForInternalByConfig(config *Config) (*grpc.ClientConn, protos.
 	var stub protos.CraneCtldForInternalClient
 
 	if config.TlsConfig.Enabled {
-		serverAddr = fmt.Sprintf("%s.%s:%s",
-			config.ControlMachine, config.TlsConfig.DomainSuffix, config.CraneCtldForInternalListenPort)
+		serverAddr = fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldForInternalListenPort)
 
 		ServerCertContent, err := os.ReadFile(config.TlsConfig.InternalCertFilePath)
 		if err != nil {

--- a/internal/util/pki.go
+++ b/internal/util/pki.go
@@ -71,10 +71,9 @@ func DoSignAndSaveUserCertificate(config *Config) error {
 		return err
 	}
 
-	serverAddr := fmt.Sprintf("%s.%s:%s",
-		config.ControlMachine, config.TlsConfig.DomainSuffix, config.CraneCtldListenPort)
+	serverAddr := fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
 
-	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, "*."+config.TlsConfig.DomainSuffix)
+	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, config.ControlMachine)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pki.go
+++ b/internal/util/pki.go
@@ -73,7 +73,7 @@ func DoSignAndSaveUserCertificate(config *Config) error {
 
 	serverAddr := fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
 
-	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, config.ControlMachine)
+	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, "*."+config.TlsConfig.DomainSuffix)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pki.go
+++ b/internal/util/pki.go
@@ -71,7 +71,7 @@ func DoSignAndSaveUserCertificate(config *Config) error {
 		return err
 	}
 
-	serverAddr := fmt.Sprintf("%s:%s", config.ControlMachine, config.CraneCtldListenPort)
+	serverAddr := fmt.Sprintf("%s:%s", config.ControlMachineConnectAddr(), config.CraneCtldListenPort)
 
 	creds, err := credentials.NewClientTLSFromFile(config.TlsConfig.CaFilePath, "*."+config.TlsConfig.DomainSuffix)
 	if err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	ClusterName                    string            `yaml:"ClusterName"`
 	ControlMachine                 string            `yaml:"ControlMachine"`
+	ControlMachineAddr             string            `yaml:"ControlMachineAddr"`
 	CraneCtldListenPort            string            `yaml:"CraneCtldListenPort"`
 	CraneCtldForInternalListenPort string            `yaml:"CraneCtldForInternalListenPort"`
 	CranedNodeList                 []ConfigNodesList `yaml:"Nodes"`
@@ -41,6 +42,13 @@ type Config struct {
 
 	Container ContainerConfig `yaml:"Container"`
 	Cfored    CforedConfig    `yaml:"Cfored"`
+}
+
+func (c *Config) ControlMachineConnectAddr() string {
+	if c.ControlMachineAddr != "" {
+		return c.ControlMachineAddr
+	}
+	return c.ControlMachine
 }
 
 type TLSConfig struct {

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -98,9 +98,9 @@ message InitSupervisorRequest {
       string ca_content = 3;
     };
 
+    reserved 3;
     bool use_tls = 1;
     TlsCertificates tls_certs = 2;
-    string domain_suffix = 3;
   }
 
   CforedListenConf cfored_listen_conf = 25;

--- a/protos/Supervisor.proto
+++ b/protos/Supervisor.proto
@@ -98,9 +98,9 @@ message InitSupervisorRequest {
       string ca_content = 3;
     };
 
-    reserved 3;
     bool use_tls = 1;
     TlsCertificates tls_certs = 2;
+    string domain_suffix = 3;
   }
 
   CforedListenConf cfored_listen_conf = 25;


### PR DESCRIPTION
## Summary
- keep TLS DomainSuffix in frontend config for user certificate issuance and the existing wildcard ServerName fallback
- connect to ControlMachine as configured instead of appending a domain suffix
- register cfored with the system hostname as-is, and add cfored --hostname for per-node overrides when the desired TLS name differs
- reserve the removed supervisor proto field to match backend protocol changes

## Verification
- git diff --cached --check
- rg -n "ControlMachine, config\.TlsConfig\.DomainSuffix|%s\.%s" internal protos
- go test ./internal/util ./internal/cfored

Paired backend PR: PKUHPC/CraneSched#967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated control-machine connection address.
  * Added a `--hostname` option for specifying the hostname used when registering cfored.
* **Bug Fixes**
  * Improved TLS and non-TLS gRPC connectivity when configured addresses differ from hostnames.
  * Corrected TLS server-name handling for internal and external connections.
  * Updated certificate operations to use the configured control-machine address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->