### PR TITLE
fix: make PTY forwarding resize-aware

### DIFF
--- a/internal/cfored/crun_server.go
+++ b/internal/cfored/crun_server.go
@@ -589,6 +589,27 @@ CforedCrunStateMachineLoop:
 								jobId, stepId, payload.GetLocalId(), payload.GetCranedId())
 							gSupervisorChanKeeper.forwardCrunRequestToSingleSupervisor(jobId, stepId, payload.GetCranedId(), crunRequest)
 
+						case protos.StreamCrunRequest_TERMINAL_RESIZE:
+							payload := crunRequest.GetPayloadTerminalResizeReq()
+							taskId := payload.GetTaskId()
+							node, ok := task_craned_map[taskId]
+							if !ok {
+								if shouldLogTerminalResizeDiagnostic() {
+									log.Warningf(
+										"[Crun->Cfored][Step #%d.%d] Ignoring terminal resize for unknown task #%d",
+										jobId, stepId, taskId,
+									)
+								}
+								break
+							}
+							log.Tracef(
+								"[Crun->Cfored->Supervisor][Step #%d.%d] Forwarding terminal resize for task #%d to Craned %s",
+								jobId, stepId, taskId, node,
+							)
+							gSupervisorChanKeeper.forwardTerminalResizeToSingleSupervisor(
+								jobId, stepId, node, crunRequest,
+							)
+
 						case protos.StreamCrunRequest_STEP_COMPLETION_REQUEST:
 							log.Debugf("[Crun->Cfored->Ctld][Step #%d.%d] Receive JobCompletionRequest", jobId, stepId)
 							toCtldRequest := &protos.StreamCforedRequest{
@@ -606,7 +627,7 @@ CforedCrunStateMachineLoop:
 							state = CrunWaitCtldAck
 							break forwarding
 						default:
-							log.Fatalf("[Crun->Cfored][Step #%d.%d] Expect JOB_COMPLETION_REQUEST or TASK_IO_FORWARD",
+							log.Fatalf("[Crun->Cfored][Step #%d.%d] Expect JOB_COMPLETION_REQUEST, TASK_IO_FORWARD, STEP_X11_FORWARD or TERMINAL_RESIZE",
 								jobId, stepId)
 							break forwarding
 						}

--- a/internal/cfored/server.go
+++ b/internal/cfored/server.go
@@ -36,9 +36,18 @@ import (
 )
 
 type RequestSupervisorChannel struct {
-	valid                 *atomic.Bool
-	crunRequestChannel    chan *protos.StreamCrunRequest
-	cattachRequestChannel chan *protos.StreamCattachRequest
+	valid                  *atomic.Bool
+	supportsTerminalResize bool
+	crunRequestChannel     chan *protos.StreamCrunRequest
+	cattachRequestChannel  chan *protos.StreamCattachRequest
+}
+
+const terminalResizeDiagnosticLimit = 8
+
+var terminalResizeDiagnosticCount atomic.Uint32
+
+func shouldLogTerminalResizeDiagnostic() bool {
+	return terminalResizeDiagnosticCount.Add(1) <= terminalResizeDiagnosticLimit
 }
 
 type FrontRequest interface {
@@ -118,13 +127,18 @@ func NewCranedChannelKeeper() *SupervisorChannelKeeper {
 	return keeper
 }
 
-func (keeper *SupervisorChannelKeeper) supervisorUpAndSetMsgToSupervisorChannel(jobId uint32, stepId uint32, cranedId string, msgChannel chan *protos.StreamCrunRequest, cattachMsgChannel chan *protos.StreamCattachRequest, valid *atomic.Bool) {
+func (keeper *SupervisorChannelKeeper) supervisorUpAndSetMsgToSupervisorChannel(jobId uint32, stepId uint32, cranedId string, msgChannel chan *protos.StreamCrunRequest, cattachMsgChannel chan *protos.StreamCattachRequest, valid *atomic.Bool, supportsTerminalResize bool) {
 	keeper.toSupervisorChannelMtx.Lock()
 	stepIdentity := StepIdentifier{JobId: jobId, StepId: stepId}
 	if _, exist := keeper.toSupervisorChannels[stepIdentity]; !exist {
 		keeper.toSupervisorChannels[stepIdentity] = make(map[string]*RequestSupervisorChannel)
 	}
-	keeper.toSupervisorChannels[stepIdentity][cranedId] = &RequestSupervisorChannel{crunRequestChannel: msgChannel, valid: valid, cattachRequestChannel: cattachMsgChannel}
+	keeper.toSupervisorChannels[stepIdentity][cranedId] = &RequestSupervisorChannel{
+		crunRequestChannel:     msgChannel,
+		valid:                  valid,
+		cattachRequestChannel:  cattachMsgChannel,
+		supportsTerminalResize: supportsTerminalResize,
+	}
 	keeper.toSupervisorChannelCV.Broadcast()
 	keeper.toSupervisorChannelMtx.Unlock()
 }
@@ -333,6 +347,7 @@ func forwardRequestToSingleSupervisorByChannel[T FrontRequest](
 	cranedId string,
 	request T,
 	getChannel func(*RequestSupervisorChannel) chan T,
+	allow func(*RequestSupervisorChannel) bool,
 ) {
 	stepIdentity := StepIdentifier{JobId: jobId, StepId: stepId}
 
@@ -365,6 +380,9 @@ func forwardRequestToSingleSupervisorByChannel[T FrontRequest](
 		)
 		return
 	}
+	if allow != nil && !allow(supervisorChannel) {
+		return
+	}
 
 	ch := getChannel(supervisorChannel)
 
@@ -391,6 +409,38 @@ func (keeper *SupervisorChannelKeeper) forwardCrunRequestToSupervisor(jobId uint
 	)
 }
 
+func (keeper *SupervisorChannelKeeper) forwardTerminalResizeToSingleSupervisor(
+	jobId uint32,
+	stepId uint32,
+	cranedId string,
+	request *protos.StreamCrunRequest,
+) {
+	forwardRequestToSingleSupervisorByChannel(
+		keeper,
+		jobId,
+		stepId,
+		cranedId,
+		request,
+		func(ch *RequestSupervisorChannel) chan *protos.StreamCrunRequest {
+			return ch.crunRequestChannel
+		},
+		func(ch *RequestSupervisorChannel) bool {
+			if ch.supportsTerminalResize {
+				return true
+			}
+			if shouldLogTerminalResizeDiagnostic() {
+				log.Debugf(
+					"[Step #%d.%d] Supervisor on Craned %s does not support terminal resize; dropping request",
+					jobId,
+					stepId,
+					cranedId,
+				)
+			}
+			return false
+		},
+	)
+}
+
 func (keeper *SupervisorChannelKeeper) forwardCrunRequestToSingleSupervisor(jobId uint32, stepId uint32,
 	cranedId string, request *protos.StreamCrunRequest) {
 	forwardRequestToSingleSupervisorByChannel(
@@ -402,6 +452,7 @@ func (keeper *SupervisorChannelKeeper) forwardCrunRequestToSingleSupervisor(jobI
 		func(ch *RequestSupervisorChannel) chan *protos.StreamCrunRequest {
 			return ch.crunRequestChannel
 		},
+		nil,
 	)
 }
 
@@ -428,6 +479,7 @@ func (keeper *SupervisorChannelKeeper) forwardCattachRequestToSingleSupervisor(j
 		func(ch *RequestSupervisorChannel) chan *protos.StreamCattachRequest {
 			return ch.cattachRequestChannel
 		},
+		nil,
 	)
 }
 
@@ -676,7 +728,8 @@ CforedSupervisorStateMachineLoop:
 
 			gSupervisorChanKeeper.supervisorUpAndSetMsgToSupervisorChannel(
 				jobId, stepId, cranedId, pendingCrunReqToSupervisorChannel,
-				pendingCattachReqToSupervisorChannel, valid)
+				pendingCattachReqToSupervisorChannel, valid,
+				cranedReq.GetPayloadRegisterReq().GetSupportsTerminalResize())
 
 			reply = &protos.StreamStepIOReply{
 				Type: protos.StreamStepIOReply_SUPERVISOR_REGISTER_REPLY,
@@ -792,6 +845,18 @@ CforedSupervisorStateMachineLoop:
 									Msg:     msg,
 									Eof:     payload.Eof,
 									LocalId: payload.LocalId,
+								},
+							},
+						}
+
+					case protos.StreamCrunRequest_TERMINAL_RESIZE:
+						payload := crunReq.GetPayloadTerminalResizeReq()
+						reply = &protos.StreamStepIOReply{
+							Type: protos.StreamStepIOReply_TERMINAL_RESIZE,
+							Payload: &protos.StreamStepIOReply_PayloadTerminalResizeReq{
+								PayloadTerminalResizeReq: &protos.StreamStepIOReply_TerminalResizeReq{
+									TerminalSize: payload.GetTerminalSize(),
+									TaskId:       payload.GetTaskId(),
 								},
 							},
 						}

--- a/internal/cfored/terminal_resize_test.go
+++ b/internal/cfored/terminal_resize_test.go
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+package cfored
+
+import (
+	"CraneFrontEnd/generated/protos"
+	"sync/atomic"
+	"testing"
+)
+
+func TestTerminalResizeRequiresSupervisorCapability(t *testing.T) {
+	keeper := NewCranedChannelKeeper()
+	valid := &atomic.Bool{}
+	valid.Store(true)
+	requests := make(chan *protos.StreamCrunRequest, 1)
+	attachments := make(chan *protos.StreamCattachRequest, 1)
+	request := &protos.StreamCrunRequest{Type: protos.StreamCrunRequest_TERMINAL_RESIZE}
+
+	keeper.supervisorUpAndSetMsgToSupervisorChannel(
+		1, 0, "craned0", requests, attachments, valid, false,
+	)
+	keeper.forwardTerminalResizeToSingleSupervisor(1, 0, "craned0", request)
+	select {
+	case <-requests:
+		t.Fatal("resize was forwarded to a supervisor without resize capability")
+	default:
+	}
+
+	keeper.supervisorUpAndSetMsgToSupervisorChannel(
+		1, 0, "craned0", requests, attachments, valid, true,
+	)
+	keeper.forwardTerminalResizeToSingleSupervisor(1, 0, "craned0", request)
+	select {
+	case got := <-requests:
+		if got != request {
+			t.Fatal("forwarded resize request does not match the original request")
+		}
+	default:
+		t.Fatal("resize was not forwarded to a supervisor with resize capability")
+	}
+}

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -31,8 +31,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
 
-	"github.com/pkg/term/termios"
 	"golang.org/x/sys/unix"
+	"golang.org/x/term"
 
 	"bufio"
 	"context"
@@ -78,7 +78,7 @@ type GlobalVariables struct {
 	globalCtx       context.Context
 	globalCtxCancel context.CancelFunc
 
-	connectionBroken bool
+	connectionBroken atomic.Bool
 }
 
 var gVars GlobalVariables
@@ -109,9 +109,12 @@ type StateMachineOfCrun struct {
 	conn   *grpc.ClientConn
 	client protos.CraneForeDClient
 	stream grpc.BidiStreamingClient[protos.StreamCrunRequest, protos.StreamCrunReply]
+	sender *crunStreamSender
 
-	sigs         chan os.Signal
-	savedPtyAttr unix.Termios
+	sigs               chan os.Signal
+	savedTerminalState *term.State
+	savedStdinFlags    int
+	terminalConfigured bool
 
 	cforedReplyReceiver *CforedReplyReceiver
 
@@ -120,8 +123,10 @@ type StateMachineOfCrun struct {
 	stopStepCb  context.CancelFunc
 	//stop step will stop reading from local stdin/file/x11
 	stopReadCtx             context.Context
+	stopReadCb              context.CancelFunc
 	stopWriteCtx            context.Context
 	stopWriteCb             context.CancelFunc
+	inputWg                 sync.WaitGroup
 	writerWg                sync.WaitGroup
 	chanInputFromLocal      chan []byte
 	chanOutputFromRemote    chan []byte
@@ -196,8 +201,30 @@ func (m *StateMachineOfCrun) Init(job *protos.JobToCtld, step *protos.StepToCtld
 }
 
 func (m *StateMachineOfCrun) Close() {
+	if m.stopReadCb != nil {
+		m.stopReadCb()
+	}
+	m.inputWg.Wait()
+	if m.stopWriteCb != nil {
+		m.stopWriteCb()
+	}
+	m.writerWg.Wait()
+
+	if m.terminalConfigured {
+		if err := term.Restore(int(os.Stdin.Fd()), m.savedTerminalState); err != nil {
+			log.Errorf("Failed to restore stdin terminal state: %s", err)
+		}
+		if _, err := unix.FcntlInt(os.Stdin.Fd(), unix.F_SETFL, m.savedStdinFlags); err != nil {
+			log.Errorf("Failed to restore stdin flags: %s", err)
+		}
+		m.terminalConfigured = false
+	}
+
 	if m.cforedReplyReceiver != nil {
 		m.cforedReplyReceiver.MarkExpectedClose()
+	}
+	if gVars.globalCtxCancel != nil {
+		gVars.globalCtxCancel()
 	}
 	if m.conn != nil {
 		err := m.conn.Close()
@@ -205,12 +232,38 @@ func (m *StateMachineOfCrun) Close() {
 			log.Errorf("Failed to close grpc conn: %s", err)
 		}
 	}
-
-	if FlagPty {
-		if err := termios.Tcsetattr(os.Stdin.Fd(), termios.TCSANOW, &m.savedPtyAttr); err != nil {
-			log.Errorf("Failed to restore stdin attr: %s", err.Error())
-		}
+	if m.sender != nil {
+		m.sender.Close()
 	}
+	signal.Stop(m.sigs)
+}
+
+func (m *StateMachineOfCrun) sendRequest(
+	ctx context.Context,
+	request *protos.StreamCrunRequest,
+) error {
+	if m.sender == nil {
+		return errors.New("crun stream sender is not initialized")
+	}
+	return m.sender.Send(ctx, request)
+}
+
+func (m *StateMachineOfCrun) configureTerminal() error {
+	if !FlagPty || m.terminalConfigured {
+		return nil
+	}
+	flags, err := unix.FcntlInt(os.Stdin.Fd(), unix.F_GETFL, 0)
+	if err != nil {
+		return fmt.Errorf("get stdin flags: %w", err)
+	}
+	state, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("set stdin raw mode: %w", err)
+	}
+	m.savedStdinFlags = flags
+	m.savedTerminalState = state
+	m.terminalConfigured = true
+	return nil
 }
 
 func (m *StateMachineOfCrun) StateConnectCfored() {
@@ -283,6 +336,7 @@ func (m *StateMachineOfCrun) StateConnectCfored() {
 		m.state = End
 		return
 	}
+	m.sender = newCrunStreamSender(gVars.globalCtx, m.stream)
 
 	m.cforedReplyReceiver = new(CforedReplyReceiver)
 	m.cforedReplyReceiver.StartReplyReceiveRoutine(m.stream)
@@ -309,10 +363,10 @@ func (m *StateMachineOfCrun) StateConnectCfored() {
 		}
 	}
 
-	if err := m.stream.Send(request); err != nil {
+	if err := m.sendRequest(gVars.globalCtx, request); err != nil {
 		log.Errorf("Failed to send Request to CrunStream: %s. "+
 			"Connection to Crun is broken", err)
-		gVars.connectionBroken = true
+		gVars.connectionBroken.Store(true)
 
 		m.state = End
 		m.err = util.ErrorNetwork
@@ -335,7 +389,7 @@ func (m *StateMachineOfCrun) StateReqJobId() {
 			default:
 				log.Errorf("Connection to Cfored broken when requesting "+
 					"job id: %s. Exiting...", err)
-				gVars.connectionBroken = true
+				gVars.connectionBroken.Store(true)
 				m.state = End
 				m.err = util.ErrorNetwork
 				return
@@ -393,7 +447,7 @@ func (m *StateMachineOfCrun) StateWaitRes() {
 			default:
 				log.Errorf("Connection to Cfored broken when waiting "+
 					"resource allocated: %s. Exiting...", err)
-				gVars.connectionBroken = true
+				gVars.connectionBroken.Store(true)
 				m.state = End
 				m.err = util.ErrorNetwork
 				return
@@ -454,7 +508,7 @@ func (m *StateMachineOfCrun) StateWaitForward() {
 			default:
 				log.Errorf("Connection to Cfored broken when waiting for forwarding user i/o "+
 					"%s. Exiting...", err)
-				gVars.connectionBroken = true
+				gVars.connectionBroken.Store(true)
 				m.state = End
 				m.err = util.ErrorNetwork
 				return
@@ -503,35 +557,14 @@ func (m *StateMachineOfCrun) StateForwarding() {
 	var request *protos.StreamCrunRequest
 	var taskIdWithInput *uint32
 
-	if FlagPty {
-		ptyAttr := unix.Termios{}
-		err := termios.Tcgetattr(os.Stdin.Fd(), &ptyAttr)
-		if err != nil {
-			log.Errorf("Failed to get stdin attr: %s,killing", err.Error())
-			m.state = JobKilling
-			m.err = util.ErrorSystem
-			return
-		}
-		m.savedPtyAttr = ptyAttr
-
-		termios.Cfmakeraw(&ptyAttr)
-		termios.Cfmakecbreak(&ptyAttr)
-		err = termios.Tcsetattr(os.Stdin.Fd(), termios.TCSANOW, &ptyAttr)
-		if err != nil {
-			log.Errorf("Failed to get stdin attr: %s,killing", err.Error())
-			m.state = JobKilling
-			m.err = util.ErrorSystem
-			return
-		}
+	if err := m.configureTerminal(); err != nil {
+		log.Errorf("Failed to initialize local terminal: %s; killing", err)
+		m.state = JobKilling
+		m.err = util.ErrorSystem
+		return
 	}
 
 	m.StartIOForward()
-	var x11ReqFromLocal chan *protos.StreamCrunRequest
-	if m.X11SessionMgr != nil {
-		x11ReqFromLocal = m.X11SessionMgr.X11RequestChan
-	} else {
-		x11ReqFromLocal = nil
-	}
 
 	parsedId, err := strconv.ParseUint(m.inputFlag, 10, 32)
 	if err == nil {
@@ -544,54 +577,10 @@ func (m *StateMachineOfCrun) StateForwarding() {
 		}
 	}
 
-	// Forward input to Cfored.
-	go func() {
-		for {
-			select {
-			case msg, ok := <-m.chanInputFromLocal:
-				if !ok {
-					msg = nil
-				}
-				request = &protos.StreamCrunRequest{
-					Type: protos.StreamCrunRequest_TASK_IO_FORWARD,
-					Payload: &protos.StreamCrunRequest_PayloadTaskIoForwardReq{
-						PayloadTaskIoForwardReq: &protos.StreamCrunRequest_TaskIOForwardReq{
-							Msg:    msg,
-							Eof:    msg == nil,
-							TaskId: taskIdWithInput,
-						},
-					},
-				}
-				if err := m.stream.Send(request); err != nil {
-					log.Errorf("Failed to send Job Request to CrunStream: %s. "+
-						"Connection to Crun is broken", err)
-					gVars.connectionBroken = true
-					return
-				}
-				if msg == nil {
-					return
-				}
-
-			case request := <-x11ReqFromLocal:
-				if err := m.stream.Send(request); err != nil {
-					log.Errorf("Failed to send Job X11 Input to CrunStream: %s. "+
-						"Connection to Crun is broken", err)
-					gVars.connectionBroken = true
-					return
-				}
-
-			//If stop reading, no more input allowed to send, otherwise may cause cfored blocked forever.
-			case <-m.stopReadCtx.Done():
-				for range m.chanInputFromLocal {
-					log.Tracef("Drained 1 msg from chanInputFromLocal after stopReadCtx done")
-				}
-				for range x11ReqFromLocal {
-					log.Tracef("Drained 1 msg from x11ReqFromLocal after stopReadCtx done")
-				}
-				return
-			}
-		}
-	}()
+	m.startInputRoutine(func() { m.forwardLocalRequests(taskIdWithInput) })
+	if FlagPty {
+		m.startInputRoutine(m.forwardTerminalResize)
+	}
 
 	for m.state == Forwarding {
 		select {
@@ -606,11 +595,11 @@ func (m *StateMachineOfCrun) StateForwarding() {
 			}
 
 			log.Debug("Sending JOB_COMPLETION_REQUEST with COMPLETED state...")
-			if err := m.stream.Send(request); err != nil {
+			if err := m.sendRequest(gVars.globalCtx, request); err != nil {
 				log.Errorf("The connection to Cfored was broken: %s. "+
 					"Exiting...", err)
-				gVars.connectionBroken = true
-				m.state = End
+				gVars.connectionBroken.Store(true)
+				m.state = JobKilling
 				m.err = util.ErrorNetwork
 			} else {
 				m.state = WaitAck
@@ -625,7 +614,7 @@ func (m *StateMachineOfCrun) StateForwarding() {
 				default:
 					log.Errorf("The connection to Cfored was broken: %s. "+
 						"Killing job...", err)
-					gVars.connectionBroken = true
+					gVars.connectionBroken.Store(true)
 					m.err = util.ErrorNetwork
 					m.state = JobKilling
 				}
@@ -681,6 +670,124 @@ func (m *StateMachineOfCrun) StateForwarding() {
 
 }
 
+func (m *StateMachineOfCrun) forwardLocalRequests(taskIdWithInput *uint32) {
+	var x11Requests <-chan *protos.StreamCrunRequest
+	if m.X11SessionMgr != nil {
+		x11Requests = m.X11SessionMgr.X11RequestChan
+	}
+
+	for {
+		select {
+		case <-m.stopReadCtx.Done():
+			return
+		case msg, ok := <-m.chanInputFromLocal:
+			eof := !ok || msg == nil
+			request := &protos.StreamCrunRequest{
+				Type: protos.StreamCrunRequest_TASK_IO_FORWARD,
+				Payload: &protos.StreamCrunRequest_PayloadTaskIoForwardReq{
+					PayloadTaskIoForwardReq: &protos.StreamCrunRequest_TaskIOForwardReq{
+						Msg:    msg,
+						Eof:    eof,
+						TaskId: taskIdWithInput,
+					},
+				},
+			}
+			if err := m.sendRequest(m.stopReadCtx, request); err != nil {
+				if m.stopReadCtx.Err() == nil {
+					log.Errorf("Failed to send task input to Cfored: %s", err)
+					gVars.connectionBroken.Store(true)
+					m.stopStepCb()
+				}
+				return
+			}
+			if eof {
+				return
+			}
+		case request := <-x11Requests:
+			if err := m.sendRequest(m.stopReadCtx, request); err != nil {
+				if m.stopReadCtx.Err() == nil {
+					log.Errorf("Failed to send X11 input to Cfored: %s", err)
+					gVars.connectionBroken.Store(true)
+					m.stopStepCb()
+				}
+				return
+			}
+		}
+	}
+}
+
+func (m *StateMachineOfCrun) forwardTerminalResize() {
+	resizeSignals := make(chan os.Signal, 1)
+	signal.Notify(resizeSignals, syscall.SIGWINCH)
+	defer signal.Stop(resizeSignals)
+
+	var previousRows, previousColumns uint32
+	var interactiveMeta *protos.InteractiveJobAdditionalMeta
+	if m.job != nil {
+		interactiveMeta = m.job.GetInteractiveMeta()
+	} else {
+		interactiveMeta = m.step.GetInteractiveMeta()
+	}
+	if initialSize := interactiveMeta.GetTerminalSize(); initialSize != nil {
+		previousRows = initialSize.GetRows()
+		previousColumns = initialSize.GetColumns()
+	}
+
+	for {
+		select {
+		case <-m.stopReadCtx.Done():
+			return
+		case <-resizeSignals:
+			// A one-element signal channel already coalesces bursts. Drain any signal
+			// queued while GetSize was running before publishing the newest size.
+			select {
+			case <-resizeSignals:
+			default:
+			}
+			columns, rows, err := term.GetSize(int(os.Stdin.Fd()))
+			if err != nil {
+				log.Warningf("Failed to read resized terminal dimensions: %s", err)
+				continue
+			}
+			if !validTerminalSize(rows, columns) {
+				log.Warningf("Ignoring invalid resized terminal dimensions %dx%d", rows, columns)
+				continue
+			}
+			if uint32(rows) == previousRows && uint32(columns) == previousColumns {
+				continue
+			}
+
+			request := &protos.StreamCrunRequest{
+				Type: protos.StreamCrunRequest_TERMINAL_RESIZE,
+				Payload: &protos.StreamCrunRequest_PayloadTerminalResizeReq{
+					PayloadTerminalResizeReq: &protos.StreamCrunRequest_TerminalResizeReq{
+						TerminalSize: &protos.TerminalSize{
+							Rows:    uint32(rows),
+							Columns: uint32(columns),
+						},
+						TaskId: 0,
+					},
+				},
+			}
+			if err := m.sendRequest(m.stopReadCtx, request); err != nil {
+				if m.stopReadCtx.Err() == nil {
+					log.Errorf("Failed to send terminal resize to Cfored: %s", err)
+					gVars.connectionBroken.Store(true)
+					m.stopStepCb()
+				}
+				return
+			}
+			previousRows, previousColumns = uint32(rows), uint32(columns)
+		}
+	}
+}
+
+func validTerminalSize(rows, columns int) bool {
+	const maxTerminalDimension = int(^uint16(0))
+	return rows > 0 && rows <= maxTerminalDimension &&
+		columns > 0 && columns <= maxTerminalDimension
+}
+
 func (m *StateMachineOfCrun) StateJobKilling() {
 	request := &protos.StreamCrunRequest{
 		Type: protos.StreamCrunRequest_STEP_COMPLETION_REQUEST,
@@ -691,7 +798,7 @@ func (m *StateMachineOfCrun) StateJobKilling() {
 		},
 	}
 
-	if gVars.connectionBroken {
+	if gVars.connectionBroken.Load() {
 		log.Errorf("The connection to Cfored was broken. Exiting...")
 		m.err = util.ErrorNetwork
 		m.state = End
@@ -699,9 +806,9 @@ func (m *StateMachineOfCrun) StateJobKilling() {
 	}
 
 	log.Debug("Sending JOB_COMPLETION_REQUEST with CANCELLED state...")
-	if err := m.stream.Send(request); err != nil {
+	if err := m.sendRequest(gVars.globalCtx, request); err != nil {
 		log.Errorf("The connection to Cfored was broken: %s. Exiting...", err)
-		gVars.connectionBroken = true
+		gVars.connectionBroken.Store(true)
 		m.err = util.ErrorNetwork
 		m.state = End
 		return
@@ -722,7 +829,7 @@ func (m *StateMachineOfCrun) StateWaitAck() {
 		default:
 			log.Errorf("The connection to Cfored was broken: %s. "+
 				"Exiting...", err)
-			gVars.connectionBroken = true
+			gVars.connectionBroken.Store(true)
 			m.err = util.ErrorNetwork
 			m.state = End
 			return
@@ -860,6 +967,8 @@ func (m *StateMachineOfCrun) forwardingSigHandlerRoutine() {
 loop:
 	for {
 		select {
+		case <-m.stopReadCtx.Done():
+			break loop
 		case sig := <-m.sigs:
 			switch sig {
 			/*
@@ -1036,12 +1145,6 @@ func (m *StateMachineOfCrun) StderrFileWriterRoutine(filePattern string) {
 }
 
 func (m *StateMachineOfCrun) StdinReaderRoutine() {
-
-	err := syscall.SetNonblock(int(os.Stdin.Fd()), true)
-	if err != nil {
-		return
-	}
-
 	epfd, err := syscall.EpollCreate1(0)
 	if err != nil {
 		log.Tracef("EpollCreate1: %v", err)
@@ -1064,19 +1167,6 @@ func (m *StateMachineOfCrun) StdinReaderRoutine() {
 	buf := make([]byte, 4096)
 reading:
 	for {
-		if FlagPty {
-			ptyAttr := unix.Termios{}
-			err := termios.Tcgetattr(os.Stdin.Fd(), &ptyAttr)
-			if err != nil {
-				log.Errorf("Failed to get stdin attr")
-			}
-			termios.Cfmakeraw(&ptyAttr)
-			err = termios.Tcsetattr(os.Stdin.Fd(), termios.TCSANOW, &ptyAttr)
-			if err != nil {
-				log.Errorf("Failed to set stdin attr")
-			}
-		}
-
 		select {
 		case <-m.stopReadCtx.Done():
 			break reading
@@ -1114,7 +1204,12 @@ reading:
 					log.Trace("Read 0 bytes (EOF), closing channel and exiting goroutine")
 					return
 				}
-				m.chanInputFromLocal <- buf[:nr]
+				data := append([]byte(nil), buf[:nr]...)
+				select {
+				case m.chanInputFromLocal <- data:
+				case <-m.stopReadCtx.Done():
+					break reading
+				}
 				log.Tracef("Sent %d bytes to channel", nr)
 			}
 		}
@@ -1268,21 +1363,29 @@ reading:
 			n, err := reader.Read(buffer)
 			if err != nil {
 				if err == io.EOF {
-					m.chanInputFromLocal <- buffer[:n]
-					m.chanInputFromLocal <- nil
+					data := append([]byte(nil), buffer[:n]...)
+					select {
+					case m.chanInputFromLocal <- data:
+					case <-m.stopReadCtx.Done():
+					}
 					break reading
 				}
 				log.Errorf("Failed to read from fd: %v", err)
 				break reading
 			}
-			m.chanInputFromLocal <- buffer[:n]
+			data := append([]byte(nil), buffer[:n]...)
+			select {
+			case m.chanInputFromLocal <- data:
+			case <-m.stopReadCtx.Done():
+				break reading
+			}
 		}
 	}
 }
 
 func (m *StateMachineOfCrun) StartIOForward() {
 	m.stopStepCtx, m.stopStepCb = context.WithCancel(context.Background())
-	m.stopReadCtx = context.WithoutCancel(m.stopStepCtx)
+	m.stopReadCtx, m.stopReadCb = context.WithCancel(m.stopStepCtx)
 	// stopWriteCtx is independent of stopStepCtx: it is only cancelled after
 	// Run() returns, at which point no more data will be written to the output
 	// channels.  This avoids a race where stopStepCtx is cancelled inside
@@ -1294,24 +1397,24 @@ func (m *StateMachineOfCrun) StartIOForward() {
 	m.chanInputFromLocal = make(chan []byte, 100)
 	m.chanOutputFromRemote = make(chan []byte, 20)
 	m.chanErrOutputFromRemote = make(chan []byte, 20)
-	go m.forwardingSigHandlerRoutine()
+	m.startInputRoutine(m.forwardingSigHandlerRoutine)
 	if strings.ToLower(m.inputFlag) == FlagIOForwardALL {
 		log.Debugf("Input from stdin to all tasks")
-		go m.StdinReaderRoutine()
+		m.startInputRoutine(m.StdinReaderRoutine)
 	} else if strings.ToLower(m.inputFlag) == FlagIOForwardNONE {
 		log.Debugf("No input forwarding")
 	} else {
 		taskId, err := strconv.ParseUint(m.inputFlag, 10, 32)
 		if err != nil {
 			log.Debugf("Input from file %s, filepath is not a number", m.inputFlag)
-			go m.FileReaderRoutine(m.inputFlag)
+			m.startInputRoutine(func() { m.FileReaderRoutine(m.inputFlag) })
 		} else {
 			if taskId < uint64(m.ntasksTotal) {
 				log.Debugf("Input from stdin to %d", taskId)
-				go m.StdinReaderRoutine()
+				m.startInputRoutine(m.StdinReaderRoutine)
 			} else {
 				log.Debugf("Input from file %s, num but greater than ntasksTotal %d", m.inputFlag, m.ntasksTotal)
-				go m.FileReaderRoutine(m.inputFlag)
+				m.startInputRoutine(func() { m.FileReaderRoutine(m.inputFlag) })
 
 			}
 		}
@@ -1377,8 +1480,16 @@ func (m *StateMachineOfCrun) StartIOForward() {
 	}
 	if iaMeta.X11 && iaMeta.GetX11Meta().EnableForwarding {
 		m.X11SessionMgr = NewX11SessionMgr(iaMeta.GetX11Meta(), &m.stopReadCtx)
-		go m.X11SessionMgr.SessionMgrRoutine()
+		m.startInputRoutine(m.X11SessionMgr.SessionMgrRoutine)
 	}
+}
+
+func (m *StateMachineOfCrun) startInputRoutine(routine func()) {
+	m.inputWg.Add(1)
+	go func() {
+		defer m.inputWg.Done()
+		routine()
+	}()
 }
 
 func (m *StateMachineOfCrun) RunCommand(runCommandArgs RunCommandArgs) int {
@@ -1861,6 +1972,25 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 		iaMeta = step.GetInteractiveMeta()
 	}
 	iaMeta.Pty = FlagPty
+	if FlagPty {
+		columns, rows, err := term.GetSize(int(os.Stdin.Fd()))
+		if err != nil {
+			return util.NewCraneErr(
+				util.ErrorSystem,
+				fmt.Sprintf("Failed to read terminal size: %s.", err),
+			)
+		}
+		if !validTerminalSize(rows, columns) {
+			return util.NewCraneErr(
+				util.ErrorSystem,
+				fmt.Sprintf("Invalid terminal size %dx%d.", rows, columns),
+			)
+		}
+		iaMeta.TerminalSize = &protos.TerminalSize{
+			Rows:    uint32(rows),
+			Columns: uint32(columns),
+		}
+	}
 
 	if FlagX11 {
 		target, port, err := util.GetX11DisplayEx(!FlagX11Fwd)
@@ -1933,14 +2063,8 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 	ioMeta.ErrorFilePattern = m.errorFlag
 
 	m.Init(job, step)
-	m.Run()
-	// After Run() returns, no more data will be sent to output channels.
-	// Cancel stopWriteCtx to signal writer goroutines to drain and flush.
-	if m.stopWriteCb != nil {
-		m.stopWriteCb()
-	}
-	m.writerWg.Wait()
 	defer m.Close()
+	m.Run()
 
 	if m.err == util.ErrorSuccess {
 		return nil

--- a/internal/crun/stream_sender.go
+++ b/internal/crun/stream_sender.go
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+package crun
+
+import (
+	"CraneFrontEnd/generated/protos"
+	"context"
+	"sync"
+)
+
+type crunRequestStream interface {
+	Send(*protos.StreamCrunRequest) error
+}
+
+type crunSendRequest struct {
+	message *protos.StreamCrunRequest
+	result  chan error
+}
+
+// crunStreamSender is the only owner allowed to call Send on CrunStream.
+// gRPC permits one concurrent reader and writer, but not multiple writers.
+type crunStreamSender struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	stream   crunRequestStream
+	requests chan crunSendRequest
+	done     chan struct{}
+	close    sync.Once
+}
+
+func newCrunStreamSender(
+	parent context.Context,
+	stream crunRequestStream,
+) *crunStreamSender {
+	ctx, cancel := context.WithCancel(parent)
+	sender := &crunStreamSender{
+		ctx:      ctx,
+		cancel:   cancel,
+		stream:   stream,
+		requests: make(chan crunSendRequest, 128),
+		done:     make(chan struct{}),
+	}
+	go sender.run()
+	return sender
+}
+
+func (sender *crunStreamSender) run() {
+	defer close(sender.done)
+	for {
+		select {
+		case <-sender.ctx.Done():
+			return
+		case request := <-sender.requests:
+			err := sender.stream.Send(request.message)
+			request.result <- err
+			if err != nil {
+				sender.cancel()
+				return
+			}
+		}
+	}
+}
+
+func (sender *crunStreamSender) Send(
+	ctx context.Context,
+	message *protos.StreamCrunRequest,
+) error {
+	result := make(chan error, 1)
+	request := crunSendRequest{message: message, result: result}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-sender.ctx.Done():
+		return sender.ctx.Err()
+	case sender.requests <- request:
+	}
+
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-sender.ctx.Done():
+		select {
+		case err := <-result:
+			return err
+		default:
+			return sender.ctx.Err()
+		}
+	}
+}
+
+func (sender *crunStreamSender) Close() {
+	sender.close.Do(sender.cancel)
+	<-sender.done
+}

--- a/internal/crun/stream_sender_test.go
+++ b/internal/crun/stream_sender_test.go
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+package crun
+
+import (
+	"CraneFrontEnd/generated/protos"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type recordingCrunStream struct {
+	active    atomic.Int32
+	maxActive atomic.Int32
+	count     atomic.Int32
+}
+
+func (stream *recordingCrunStream) Send(*protos.StreamCrunRequest) error {
+	active := stream.active.Add(1)
+	for {
+		maximum := stream.maxActive.Load()
+		if active <= maximum || stream.maxActive.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	time.Sleep(time.Millisecond)
+	stream.count.Add(1)
+	stream.active.Add(-1)
+	return nil
+}
+
+func TestCrunStreamSenderSerializesConcurrentWriters(t *testing.T) {
+	stream := &recordingCrunStream{}
+	sender := newCrunStreamSender(context.Background(), stream)
+	defer sender.Close()
+
+	const requestCount = 64
+	var writers sync.WaitGroup
+	for range requestCount {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			if err := sender.Send(context.Background(), &protos.StreamCrunRequest{}); err != nil {
+				t.Errorf("Send() returned error: %v", err)
+			}
+		}()
+	}
+	writers.Wait()
+
+	if got := stream.count.Load(); got != requestCount {
+		t.Fatalf("Send() count = %d, want %d", got, requestCount)
+	}
+	if got := stream.maxActive.Load(); got != 1 {
+		t.Fatalf("maximum concurrent stream.Send calls = %d, want 1", got)
+	}
+}
+
+type blockingCrunStream struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (stream *blockingCrunStream) Send(*protos.StreamCrunRequest) error {
+	close(stream.started)
+	<-stream.release
+	return nil
+}
+
+func TestCrunStreamSenderCallerCanCancelBlockedSend(t *testing.T) {
+	stream := &blockingCrunStream{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	sender := newCrunStreamSender(context.Background(), stream)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- sender.Send(ctx, &protos.StreamCrunRequest{})
+	}()
+
+	<-stream.started
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Send() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Send() did not return after its context was cancelled")
+	}
+
+	close(stream.release)
+	sender.Close()
+}
+
+type failingCrunStream struct {
+	err error
+}
+
+func (stream *failingCrunStream) Send(*protos.StreamCrunRequest) error {
+	return stream.err
+}
+
+func TestCrunStreamSenderStopsAfterSendFailure(t *testing.T) {
+	wantErr := errors.New("send failed")
+	sender := newCrunStreamSender(
+		context.Background(),
+		&failingCrunStream{err: wantErr},
+	)
+	defer sender.Close()
+
+	if err := sender.Send(context.Background(), &protos.StreamCrunRequest{}); !errors.Is(err, wantErr) {
+		t.Fatalf("first Send() error = %v, want %v", err, wantErr)
+	}
+	if err := sender.Send(context.Background(), &protos.StreamCrunRequest{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("second Send() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestValidTerminalSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		rows, columns int
+		want          bool
+	}{
+		{name: "normal", rows: 24, columns: 80, want: true},
+		{name: "maximum", rows: 65535, columns: 65535, want: true},
+		{name: "zero rows", rows: 0, columns: 80},
+		{name: "zero columns", rows: 24, columns: 0},
+		{name: "rows overflow", rows: 65536, columns: 80},
+		{name: "columns overflow", rows: 24, columns: 65536},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := validTerminalSize(test.rows, test.columns); got != test.want {
+				t.Fatalf("validTerminalSize(%d, %d) = %t, want %t", test.rows, test.columns, got, test.want)
+			}
+		})
+	}
+}

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -999,6 +999,7 @@ message StreamCrunRequest {
     STEP_COMPLETION_REQUEST = 1;
     TASK_IO_FORWARD = 2;
     STEP_X11_FORWARD = 3;
+    TERMINAL_RESIZE = 5;
   }
 
   message JobReq {
@@ -1028,6 +1029,11 @@ message StreamCrunRequest {
     string craned_id = 4;
   }
 
+  message TerminalResizeReq {
+    TerminalSize terminal_size = 1;
+    uint32 task_id = 2;
+  }
+
   CrunRequestType type = 1;
 
   oneof payload {
@@ -1036,6 +1042,7 @@ message StreamCrunRequest {
     StepCompleteReq payload_step_complete_req = 3;
     TaskIOForwardReq payload_task_io_forward_req = 4;
     StepX11ForwardReq payload_step_x11_forward_req = 5;
+    TerminalResizeReq payload_terminal_resize_req = 7;
   }
 }
 
@@ -1225,6 +1232,7 @@ message StreamStepIORequest {
     string craned_id = 1;
     uint32 job_id = 2;
     uint32 step_id = 3;
+    bool supports_terminal_resize = 4;
   }
 
   message TaskOutputReq {
@@ -1280,6 +1288,7 @@ message StreamStepIOReply {
     TASK_INPUT = 1;
     SUPERVISOR_UNREGISTER_REPLY = 2;
     STEP_X11_INPUT = 3;
+    TERMINAL_RESIZE = 4;
   }
 
   message SupervisorRegisterReply {
@@ -1302,6 +1311,11 @@ message StreamStepIOReply {
     uint32 local_id = 3;
   }
 
+  message TerminalResizeReq {
+    TerminalSize terminal_size = 1;
+    uint32 task_id = 2;
+  }
+
   SupervisorReplyType type = 1;
 
   oneof payload {
@@ -1309,6 +1323,7 @@ message StreamStepIOReply {
     TaskInputReq payload_task_input_req = 3;
     SupervisorUnregisterReply payload_supervisor_unregister_reply = 4;
     StepX11InputReq payload_step_x11_input_req = 5;
+    TerminalResizeReq payload_terminal_resize_req = 6;
   }
 }
 

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -515,6 +515,11 @@ message X11Meta {
   bool enable_forwarding = 4;
 }
 
+message TerminalSize {
+  uint32 rows = 1;
+  uint32 columns = 2;
+}
+
 message InteractiveJobAdditionalMeta {
   string cfored_name = 1;
   string term_env = 3;
@@ -529,6 +534,8 @@ message InteractiveJobAdditionalMeta {
   optional uint32 input_task_id = 8;
 
   string mpi = 9;
+
+  TerminalSize terminal_size = 10;
 }
 
 message PodJobAdditionalMeta {


### PR DESCRIPTION
## Summary
- add terminal resize protocol and Supervisor capability negotiation
- serialize crun stream sends across stdin, X11, resize, and completion
- restore terminal state and add lifecycle/race coverage

## Verification
- go test -race ./... passed
- generated protobufs verified
- no live cluster or PuTTY validation in this first stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Interactive jobs now automatically detect and forward terminal window resizing.
  - Terminal dimensions are included when starting interactive sessions.
  - Resize requests are supported only by compatible supervisors.

- **Bug Fixes**
  - Improved handling of interrupted or completed interactive sessions.
  - Prevented unsupported resize requests from being forwarded.
  - Improved terminal restoration and shutdown behavior when sessions end or encounter errors.

- **Reliability**
  - Improved streaming stability by safely coordinating concurrent input and output operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->