### PR TITLE
fix: Fix -v parse

### DIFF
--- a/internal/calloc/cmd.go
+++ b/internal/calloc/cmd.go
@@ -66,8 +66,8 @@ var (
 	FlagLicenses string
 	// not implement feature:
 	FlagNTasks  string
-	FlagNoKill  string
-	FlagVerbose string
+	FlagNoKill  bool
+	FlagVerbose bool
 
 	RootCmd = &cobra.Command{
 		Use:     "calloc",
@@ -125,6 +125,6 @@ func init() {
 	RootCmd.Flags().BoolVarP(&FlagQuiet, "quiet", "Q", false, "Quiet mode (suppress informational messages)")
 	RootCmd.Flags().StringVarP(&FlagDependency, "dependency", "d", "", "Conditions for job to execute")
 	RootCmd.Flags().StringVarP(&FlagSignal, "signal", "s", "", "Send signal when time limit within time seconds, format: [{R}:]<sig_num>[@sig_time]")
-	RootCmd.Flags().StringVarP(&FlagNoKill, "no-kill", "k", "", "")
-	RootCmd.Flags().StringVarP(&FlagVerbose, "verbose", "v", "", "")
+	RootCmd.Flags().BoolVarP(&FlagNoKill, "no-kill", "k", false, "")
+	RootCmd.Flags().BoolVar(&FlagVerbose, "verbose", false, "")
 }

--- a/internal/cbatch/cmd.go
+++ b/internal/cbatch/cmd.go
@@ -81,7 +81,7 @@ var (
 
 	// not implement feature:
 	FlagNTasks          string
-	FlagParsable        string
+	FlagParsable        bool
 	FlagNTasksPerSocket string
 	FlagCpuFreq         string
 	FlagPriority        string
@@ -197,7 +197,7 @@ func init() {
 	RootCmd.MarkFlagsMutuallyExclusive("repeat", "array")
 	RootCmd.Flags().StringVarP(&FlagDependency, "dependency", "d", "", "Conditions for job to execute")
 	RootCmd.Flags().StringVarP(&FlagSignal, "signal", "s", "", "Send signal when time limit within time seconds, format: [{R|B}:]<sig_num>[@sig_time]")
-	RootCmd.Flags().StringVar(&FlagParsable, "parsable", "", "")
+	RootCmd.Flags().BoolVar(&FlagParsable, "parsable", false, "")
 	RootCmd.Flags().StringVar(&FlagNTasksPerSocket, "ntasks-per-socket", "", "")
 	RootCmd.Flags().StringVar(&FlagCpuFreq, "cpu-freq", "", "")
 	RootCmd.Flags().StringVar(&FlagPriority, "priority", "", "")

--- a/internal/crun/cmd.go
+++ b/internal/crun/cmd.go
@@ -82,7 +82,7 @@ var (
 	FlagDeadline      string
 	FlagWait          string
 	FlagMpi           string
-	FlagVerbose       string
+	FlagVerbose       bool
 	FlagError         string
 	FlagKillOnBadExit string
 	FlagExtraNodeInfo string
@@ -167,7 +167,7 @@ func init() {
 	RootCmd.Flags().StringVar(&FlagOversubscribe, "oversubscribe", "", "")
 	RootCmd.Flags().StringVar(&FlagCpuBind, "cpu-bind", "", "")
 	RootCmd.Flags().StringVar(&FlagWait, "wait", "", "")
-	RootCmd.Flags().StringVar(&FlagVerbose, "verbose", "", "")
+	RootCmd.Flags().BoolVar(&FlagVerbose, "verbose", false, "")
 	RootCmd.Flags().StringVar(&FlagError, "error", "", "")
 	RootCmd.Flags().StringVar(&FlagKillOnBadExit, "kill-on-bad-exit", "", "")
 	RootCmd.Flags().StringVar(&FlagExtraNodeInfo, "extra-node-info", "", "")

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -542,6 +542,11 @@ func salloc() *cobra.Command {
 			calloc.RootCmd.Use = "salloc"
 			// Add --help from calloc
 			calloc.RootCmd.InitDefaultHelpFlag()
+			for i, arg := range args {
+				if arg == "-v" {
+					args[i] = "--verbose"
+				}
+			}
 
 			// Parse flags
 			if err := calloc.RootCmd.ParseFlags(args); err != nil {
@@ -565,8 +570,8 @@ func salloc() *cobra.Command {
 		},
 	}
 	// not implement feature:
-	cmd.Flags().StringVarP(&calloc.FlagNoKill, "no-kill", "k", "", "")
-	cmd.Flags().StringVarP(&calloc.FlagVerbose, "verbose", "v", "", "")
+	cmd.Flags().BoolVarP(&calloc.FlagNoKill, "no-kill", "k", false, "")
+	cmd.Flags().BoolVarP(&calloc.FlagVerbose, "verbose", "v", false, "")
 
 	return cmd
 }
@@ -681,7 +686,7 @@ func sbatch() *cobra.Command {
 		},
 	}
 	// not implement feature:
-	cmd.Flags().StringVar(&cbatch.FlagParsable, "parsable", "", "")
+	cmd.Flags().BoolVar(&cbatch.FlagParsable, "parsable", false, "")
 	cmd.Flags().StringVar(&cbatch.FlagNTasksPerSocket, "ntasks-per-socket", "", "")
 	cmd.Flags().StringVar(&cbatch.FlagCpuFreq, "cpu-freq", "", "")
 	cmd.Flags().StringVar(&cbatch.FlagPriority, "priority", "", "")
@@ -1131,6 +1136,11 @@ func srun() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			crun.RootCmd.Use = "srun [flags] executable"
 			crun.RootCmd.InitDefaultHelpFlag()
+			for i, arg := range args {
+				if arg == "-v" {
+					args[i] = "--verbose"
+				}
+			}
 
 			if err := crun.RootCmd.ParseFlags(args); err != nil {
 				log.Error(err)
@@ -1158,7 +1168,7 @@ func srun() *cobra.Command {
 	cmd.Flags().StringVarP(&crun.FlagWait, "wait", "w", "", "")
 	cmd.Flags().StringVar(&crun.FlagMpi, "mpi", "", "")
 	cmd.Flags().StringVarP(&crun.FlagDependency, "dependency", "d", "", "")
-	cmd.Flags().StringVarP(&crun.FlagVerbose, "verbose", "v", "", "")
+	cmd.Flags().BoolVarP(&crun.FlagVerbose, "verbose", "v", false, "")
 	cmd.Flags().StringVarP(&crun.FlagError, "error", "e", "", "")
 	cmd.Flags().StringVarP(&crun.FlagKillOnBadExit, "kill-on-bad-exit", "k", "", "")
 	cmd.Flags().StringVarP(&crun.FlagExtraNodeInfo, "extra-node-info", "B", "", "")
@@ -1204,7 +1214,7 @@ func PrintSrunIgnoreDummyArgsMessage() {
 	if crun.FlagDependency != "" {
 		log.Warning("The feature --dependency/-d is not yet supported by Crane, the use is ignored.")
 	}
-	if crun.FlagVerbose != "" {
+	if crun.FlagVerbose {
 		log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
 	}
 	if crun.FlagError != "" {
@@ -1231,16 +1241,16 @@ func PrintSrunIgnoreDummyArgsMessage() {
 }
 
 func PrintSallocIgnoreDummyArgsMessage() {
-	if calloc.FlagNoKill != "" {
+	if calloc.FlagNoKill {
 		log.Warning("The feature --no-kill/-k is not yet supported by Crane, the use is ignored.")
 	}
-	if calloc.FlagVerbose != "" {
+	if calloc.FlagVerbose {
 		log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
 	}
 }
 
 func PrintSbatchIgnoreArgsMessage() {
-	if cbatch.FlagParsable != "" {
+	if cbatch.FlagParsable {
 		log.Warning("The feature --parsable is not yet supported by Crane, the use is ignored.")
 	}
 	if cbatch.FlagNTasksPerSocket != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional job, CPU, socket, thread, distribution, labeling, and wait-related command-line options.
  * Added short `-k` support for disabling termination behavior.
* **Improvements**
  * Updated verbose, parsable, and termination-related options to use standard boolean flag values.
  * Improved handling of short `-v` verbose arguments.
  * Unsupported option notices are now presented as warnings for clearer command-line feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->