### PR TITLE
fix: fix slurm wrapper bugs

### DIFF
--- a/internal/cacctmgr/help.go
+++ b/internal/cacctmgr/help.go
@@ -309,7 +309,7 @@ func showHelp() {
 	--config, -C            Specify config file path (default: /etc/crane/config.yaml)
 	--plugin-config, -p     Specify plugin config file path (default: /etc/crane/plugin.yaml)
 	--json, -J              Format output as JSON
-	--version, -v           Display program version
+	-V, --version           Display program version
 	--force, -f             Force operation without confirmation
 	--partition-limit, -P   Display partition resource limits (for show account/user)
 

--- a/internal/cacctmgr/parser.go
+++ b/internal/cacctmgr/parser.go
@@ -381,7 +381,7 @@ func preParseGlobalFlags(args []string) []string {
 		case "-h", "--help":
 			showHelp()
 			os.Exit(0)
-		case "-v", "--version":
+		case "-v", "-V", "--version":
 			fmt.Println(util.Version())
 			os.Exit(0)
 		case "-J", "--json":

--- a/internal/cbatch/cmd.go
+++ b/internal/cbatch/cmd.go
@@ -82,6 +82,7 @@ var (
 	// not implement feature:
 	FlagNTasks          string
 	FlagParsable        bool
+	FlagVerbose         bool
 	FlagNTasksPerSocket string
 	FlagCpuFreq         string
 	FlagPriority        string
@@ -198,6 +199,7 @@ func init() {
 	RootCmd.Flags().StringVarP(&FlagDependency, "dependency", "d", "", "Conditions for job to execute")
 	RootCmd.Flags().StringVarP(&FlagSignal, "signal", "s", "", "Send signal when time limit within time seconds, format: [{R|B}:]<sig_num>[@sig_time]")
 	RootCmd.Flags().BoolVar(&FlagParsable, "parsable", false, "")
+	RootCmd.Flags().BoolVar(&FlagVerbose, "verbose", false, "")
 	RootCmd.Flags().StringVar(&FlagNTasksPerSocket, "ntasks-per-socket", "", "")
 	RootCmd.Flags().StringVar(&FlagCpuFreq, "cpu-freq", "", "")
 	RootCmd.Flags().StringVar(&FlagPriority, "priority", "", "")

--- a/internal/cbatch/line.go
+++ b/internal/cbatch/line.go
@@ -60,7 +60,7 @@ type sLineProcessor struct {
 func (s *sLineProcessor) init() {
 	s.supported = map[string]bool{
 		"-c": true, "--cpus-per-task": true, "-J": true, "--job-name": true, "-N": true, "-q": true, "--qos": true,
-		"--nodes": true, "-A": true, "--account": true, "-e": true, "-x": true, "--exclude": true, "-D": true, "--chdir": true,
+		"--nodes": true, "-A": true, "--account": true, "-e": true, "--error": true, "-x": true, "--exclude": true, "-D": true, "--chdir": true,
 		"--export": true, "--mem": true, "-p": true, "--partition": true, "-i": true, "--input": true, "-o": true, "--output": true,
 		"--nodelist": true, "-w": true, "--get-user-env": true, "--time": true, "-t": true, "--ntasks-per-node": true,
 		"--ntasks": true, "-n": true, "--mail-type": true, "--mail-user": true, "--comment": true, "--open-mode": true,
@@ -79,7 +79,11 @@ func (s *sLineProcessor) Process(line string, sh *[]string, args *[]CbatchArg) e
 	if len(split) == 3 {
 		name := split[1]
 		if s.supported[name] {
-			*args = append(*args, CbatchArg{name: name, val: split[2]})
+			val := split[2]
+			if name == "-t" || name == "--time" {
+				val = ConvertSlurmTimeFormat(val)
+			}
+			*args = append(*args, CbatchArg{name: name, val: val})
 		} else if _, found := unsupportedFlagMessage(name); found {
 			log.Warnf("Slurm option %v is not supported", name)
 		} else {
@@ -90,7 +94,11 @@ func (s *sLineProcessor) Process(line string, sh *[]string, args *[]CbatchArg) e
 		name := parts[0]
 		if s.supported[name] {
 			if len(parts) > 1 {
-				*args = append(*args, CbatchArg{name: name, val: parts[1]})
+				val := parts[1]
+				if name == "-t" || name == "--time" {
+					val = ConvertSlurmTimeFormat(val)
+				}
+				*args = append(*args, CbatchArg{name: name, val: val})
 			} else {
 				*args = append(*args, CbatchArg{name: name})
 			}
@@ -103,6 +111,27 @@ func (s *sLineProcessor) Process(line string, sh *[]string, args *[]CbatchArg) e
 		return errors.New("fields out of bound")
 	}
 	return nil
+}
+
+func ConvertSlurmTimeFormat(t string) string {
+	// minutes | minutes:seconds | days-hours | days-hours:minutes
+	re := regexp.MustCompile(`^(?:(\d+)-(\d+)(?::(\d+))?|(\d+)(?::(\d+))?)$`)
+	x := re.FindStringSubmatch(t)
+	if x == nil {
+		return t
+	}
+	if x[1] != "" {
+		M := x[3]
+		if M == "" {
+			M = "0"
+		}
+		return fmt.Sprintf("%s-%s:%s:0", x[1], x[2], M)
+	}
+	S := x[5]
+	if S == "" {
+		S = "0"
+	}
+	return fmt.Sprintf("0:%s:%s", x[4], S)
 }
 
 // for LSF args

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -243,10 +243,8 @@ func executeShowTraceCommand(command *CControlCommand) error {
 }
 
 func executeShowConfigCommand(command *CControlCommand) error {
-	if err := ShowConfig(FlagConfigFilePath); err != nil {
-		return util.WrapCraneErr(util.ErrorGeneric, "show config failed: %s", err)
-	}
-	return nil
+	// ShowConfig already returns *util.CraneError with a specific code.
+	return ShowConfig(FlagConfigFilePath)
 }
 
 func executeUpdateCommand(command *CControlCommand) error {

--- a/internal/ccontrol/cmd.go
+++ b/internal/ccontrol/cmd.go
@@ -98,7 +98,8 @@ func ParseCmdArgs(args []string) {
 
 func executeCommand(command *CControlCommand) error {
 	action := command.GetAction()
-	if action == "show" && command.GetEntity() == "hostnames" {
+	if action == "show" &&
+		(command.GetEntity() == "hostnames" || command.GetEntity() == "config") {
 		return executeShowCommand(command)
 	}
 
@@ -133,6 +134,8 @@ func executeShowCommand(command *CControlCommand) error {
 		return executeShowHostnamesCommand(command)
 	case "trace":
 		return executeShowTraceCommand(command)
+	case "config":
+		return executeShowConfigCommand(command)
 	default:
 		return util.NewCraneErr(util.ErrorCmdArg, fmt.Sprintf("unknown entity type: %s\n", entity))
 	}
@@ -235,6 +238,13 @@ func executeShowLicenseCommand(command *CControlCommand) error {
 func executeShowTraceCommand(command *CControlCommand) error {
 	if err := ShowTraceConfig(); err != nil {
 		return util.WrapCraneErr(util.ErrorGeneric, "show trace failed: %s", err)
+	}
+	return nil
+}
+
+func executeShowConfigCommand(command *CControlCommand) error {
+	if err := ShowConfig(FlagConfigFilePath); err != nil {
+		return util.WrapCraneErr(util.ErrorGeneric, "show config failed: %s", err)
 	}
 	return nil
 }

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -50,6 +50,7 @@ ENTITIES:
   lic         - Licenses
   hostnames   - Expand a hostlist expression
   trace       - Runtime tracing configuration
+  config      - Configuration file contents
 
 COMMANDS:
   show node [<nodename>]
@@ -78,6 +79,9 @@ COMMANDS:
 
   show trace
     Show runtime tracing configuration and the compiled tracing limit.
+
+  show config
+    Show the contents of the configuration file.
 
   update nodeName=<nodename> state=<state> [reason=<reason>]
     Update attributes of a node.

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -136,7 +136,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
   --help, -h     Display this help message
-  --version, -v  Show version information
+  -V, --version  Show version information
   --json, -J     Format output as JSON
   --config, -C   Specify an alternative configuration file
   

--- a/internal/ccontrol/parser.go
+++ b/internal/ccontrol/parser.go
@@ -326,7 +326,7 @@ func preParseGlobalFlags(args []string) []string {
 		case "-h", "--help":
 			showHelp()
 			os.Exit(0)
-		case "-v", "--version":
+		case "-v", "-V", "--version":
 			fmt.Println(util.Version())
 			os.Exit(0)
 		case "-J", "--json":

--- a/internal/ccontrol/parser.go
+++ b/internal/ccontrol/parser.go
@@ -113,6 +113,7 @@ type EntityType struct {
 	PartitionAcl bool `parser:"| @'partition-acl'"`
 	JobHistory   bool `parser:"| @'job-history'"`
 	Trace        bool `parser:"| @'trace'"`
+	Config       bool `parser:"| @'config'"`
 }
 
 var CControlLexer = lexer.MustSimple([]lexer.SimpleRule{
@@ -162,6 +163,8 @@ func (e EntityType) String() string {
 		return "job-history"
 	case e.Trace:
 		return "trace"
+	case e.Config:
+		return "config"
 	default:
 		return ""
 	}

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -31,7 +31,9 @@ import (
 	"CraneFrontEnd/internal/creport"
 	"CraneFrontEnd/internal/crun"
 	"CraneFrontEnd/internal/util"
+	"fmt"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -111,16 +113,26 @@ func sacct() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cacct.RootCmd.Use = "sacct [flags]"
 			convertedArgs := make([]string, 0, len(args))
-			for _, arg := range args {
-				switch arg {
-				case "--jobs":
+			for i := 0; i < len(args); i++ {
+				arg := args[i]
+				switch {
+				case arg == "--jobs":
 					convertedArgs = append(convertedArgs, "--job")
-				case "--starttime":
+				case arg == "--starttime":
 					convertedArgs = append(convertedArgs, "--start-time")
-				case "--endtime":
+				case arg == "--endtime":
 					convertedArgs = append(convertedArgs, "--end-time")
-				case "-n":
+				case arg == "-n":
 					convertedArgs = append(convertedArgs, "-N")
+				case arg == "-o" || arg == "--format":
+					convertedArgs = append(convertedArgs, arg)
+					if i+1 < len(args) {
+						convertedArgs = append(convertedArgs, convertSacctFormat(args[i+1]))
+						i++
+					}
+				case strings.HasPrefix(arg, "--format="):
+					convertedArgs = append(convertedArgs,
+						"--format="+convertSacctFormat(strings.TrimPrefix(arg, "--format=")))
 				default:
 					convertedArgs = append(convertedArgs, arg)
 				}
@@ -149,6 +161,37 @@ func sacct() *cobra.Command {
 		"Use this comma separated list of user names to select jobs to display.")
 
 	return cmd
+}
+
+var sacctFormatSpecRegex = regexp.MustCompile(`%\.?\d*[a-zA-Z]`)
+
+// Field names that Slurm and cacct spell differently.
+var sacctFieldAliases = map[string]string{
+	"elapsed": "ElapsedTime",
+	"user":    "UserName",
+	"nnodes":  "NodeNum",
+	"start":   "StartTime",
+	"end":     "EndTime",
+	"submit":  "SubmitTime",
+}
+
+// convertSacctFormat converts a Slurm-style comma separated field name list
+// (e.g. "JobID,JobName%20,Elapsed") into the %-specifier format accepted by
+// cacct. Values already written in the %-specifier format are left unchanged.
+func convertSacctFormat(format string) string {
+	if sacctFormatSpecRegex.MatchString(format) {
+		return format
+	}
+	fields := strings.Split(format, ",")
+	specifiers := make([]string, 0, len(fields))
+	for _, field := range fields {
+		name, width, _ := strings.Cut(field, "%")
+		if alias, ok := sacctFieldAliases[strings.ToLower(name)]; ok {
+			name = alias
+		}
+		specifiers = append(specifiers, "%"+width+name)
+	}
+	return strings.Join(specifiers, " ")
 }
 
 func sacctmgr() *cobra.Command {
@@ -667,6 +710,14 @@ func sbatch() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cbatch.RootCmd.Use = "sbatch [flags] file"
 			cbatch.RootCmd.InitDefaultHelpFlag()
+			cbatch.RootCmd.InitDefaultVersionFlag()
+			for i, arg := range args {
+				if (arg == "-t" || arg == "--time") && i+1 < len(args) {
+					args[i+1] = cbatch.ConvertSlurmTimeFormat(args[i+1])
+				} else if strings.HasPrefix(arg, "--time=") {
+					args[i] = "--time=" + cbatch.ConvertSlurmTimeFormat(strings.TrimPrefix(arg, "--time="))
+				}
+			}
 
 			if err := cbatch.RootCmd.ParseFlags(args); err != nil {
 				log.Error(err)
@@ -675,6 +726,10 @@ func sbatch() *cobra.Command {
 			args = cbatch.RootCmd.Flags().Args()
 			if help, err := cbatch.RootCmd.Flags().GetBool("help"); err != nil || help {
 				return cbatch.RootCmd.Help()
+			}
+			if version, err := cbatch.RootCmd.Flags().GetBool("version"); err == nil && version {
+				fmt.Println(util.Version())
+				return nil
 			}
 			PrintSbatchIgnoreArgsMessage()
 			cbatch.RootCmd.PersistentPreRun(cmd, args)
@@ -893,6 +948,8 @@ func normalizeScontrolShowEntity(arg string) (string, bool) {
 		return "lic", true
 	case "lic":
 		return "lic", true
+	case "config":
+		return "config", true
 	default:
 		return "", false
 	}
@@ -937,17 +994,19 @@ func sinfo() *cobra.Command {
 		Short:   "View node and partition information",
 		Long:    "",
 		GroupID: "slurm",
+		Version: util.Version(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cinfo.RootCmd.PersistentPreRun(cmd, args)
 			return cinfo.RootCmd.RunE(cmd, args)
 		},
 	}
+	cmd.SetVersionTemplate(util.VersionTemplate())
 
 	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	// cmd.Flags().BoolVarP(&cinfo.FlagSummarize, "summarize", "s", false,
 	// 	"List only a partition state summary with no node state details.")
-	// cmd.Flags().BoolVarP(&cinfo.FlagListReason, "list-reasons", "R", false,
-	// 	"List reasons nodes are in the down, drained, fail or failing state.")
+	cmd.Flags().BoolVarP(&cinfo.FlagListReason, "list-reasons", "R", false,
+		"List reasons nodes are in the down, drained, fail or failing state.")
 
 	cmd.Flags().BoolVarP(&cinfo.FlagFilterDownOnly, "dead", "d", false,
 		"If set, only report state information for non-responding (dead) nodes.")
@@ -977,14 +1036,24 @@ func squeue() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cqueue.RootCmd.Use = "squeue [flags]"
 			convertedArgs := make([]string, 0, len(args))
-			for _, arg := range args {
-				switch arg {
-				case "-h":
+			for i := 0; i < len(args); i++ {
+				arg := args[i]
+				switch {
+				case arg == "-h":
 					convertedArgs = append(convertedArgs, "-N")
-				case "--jobs":
+				case arg == "--jobs":
 					convertedArgs = append(convertedArgs, "--job")
-				case "--states":
+				case arg == "--states":
 					convertedArgs = append(convertedArgs, "--state")
+				case arg == "-o" || arg == "--format":
+					convertedArgs = append(convertedArgs, arg)
+					if i+1 < len(args) {
+						convertedArgs = append(convertedArgs, convertSqueueFormat(args[i+1]))
+						i++
+					}
+				case strings.HasPrefix(arg, "--format="):
+					convertedArgs = append(convertedArgs,
+						"--format="+convertSqueueFormat(strings.TrimPrefix(arg, "--format=")))
 				default:
 					convertedArgs = append(convertedArgs, arg)
 				}
@@ -1065,6 +1134,35 @@ Example: --format "%.5jobid %.20n %t" would output the job's ID with a minimum w
          Name with a minimum width of 20, and the State.
 `)
 	return cmd
+}
+
+var squeueFormatSpecRegex = regexp.MustCompile(`%(\.?\d*)([a-zA-Z]+)`)
+
+// Single-letter format specifiers that Slurm and cqueue assign different
+// meanings to. Letters sharing the same meaning need no entry.
+var squeueFormatSpecMapping = map[string]string{
+	"i": "j", // job id
+	"j": "n", // job name
+	"n": "r", // requested nodes
+	"M": "e", // elapsed time
+	"m": "M", // requested memory per node
+	"D": "N", // number of nodes
+	"N": "L", // node list
+	"T": "t", // job state
+	"V": "s", // submit time
+}
+
+// convertSqueueFormat rewrites the Slurm single-letter format specifiers in a
+// format string to their cqueue equivalents. Multi-letter (cqueue-style)
+// specifiers and unmapped letters are left unchanged.
+func convertSqueueFormat(format string) string {
+	return squeueFormatSpecRegex.ReplaceAllStringFunc(format, func(spec string) string {
+		sub := squeueFormatSpecRegex.FindStringSubmatch(spec)
+		if converted, ok := squeueFormatSpecMapping[sub[2]]; ok {
+			return "%" + sub[1] + converted
+		}
+		return spec
+	})
 }
 
 func sreport() *cobra.Command {

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -112,10 +112,14 @@ func sacct() *cobra.Command {
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cacct.RootCmd.Use = "sacct [flags]"
+			// Slurm uses -V for version and -v for verbose.
+			cacct.RootCmd.Flags().BoolP("version", "V", false, "version for sacct")
 			convertedArgs := make([]string, 0, len(args))
 			for i := 0; i < len(args); i++ {
 				arg := args[i]
 				switch {
+				case isSlurmVerboseArg(arg) || arg == "--verbose":
+					log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
 				case arg == "--jobs":
 					convertedArgs = append(convertedArgs, "--job")
 				case arg == "--starttime":
@@ -222,6 +226,14 @@ func normalizeSacctmgrArgs(args []string) []string {
 		arg := args[i]
 
 		if strings.HasPrefix(arg, "-") {
+			// Slurm uses -V for version and -v for verbose.
+			if isSlurmVerboseArg(arg) || arg == "--verbose" {
+				log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
+				continue
+			}
+			if arg == "-V" {
+				arg = "--version"
+			}
 			convertedArgs = append(convertedArgs, arg)
 			if wrapperFlagConsumesValue(arg) && i+1 < len(args) {
 				convertedArgs = append(convertedArgs, args[i+1])
@@ -574,6 +586,12 @@ func wrapperFlagConsumesValue(arg string) bool {
 	}
 }
 
+// isSlurmVerboseArg reports whether arg is Slurm's -v verbose option,
+// which allows repeated forms such as -vv.
+func isSlurmVerboseArg(arg string) bool {
+	return len(arg) > 1 && strings.TrimRight(arg, "v") == "-"
+}
+
 func salloc() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "salloc",
@@ -588,8 +606,7 @@ func salloc() *cobra.Command {
 			// Slurm uses -V for version and -v for verbose.
 			calloc.RootCmd.Flags().BoolP("version", "V", false, "version for salloc")
 			for i, arg := range args {
-				// Slurm allows repeated -v options such as -vv.
-				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
+				if isSlurmVerboseArg(arg) {
 					args[i] = "--verbose"
 				}
 			}
@@ -636,6 +653,7 @@ func scancel() *cobra.Command {
 		FlagNodeList       []string
 		FlagConfigFilePath string
 		FlagJson           bool
+		FlagVerbose        bool
 	)
 	cmd := &cobra.Command{
 		Use:     "scancel",
@@ -644,6 +662,9 @@ func scancel() *cobra.Command {
 		GroupID: "slurm",
 		Version: util.Version(),
 		Run: func(cmd *cobra.Command, args []string) {
+			if FlagVerbose {
+				log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
+			}
 			// scancel uses spaced arguments,
 			// we need to convert it into a comma-separated list.
 			ccancelArgs := make([]string, 0)
@@ -689,9 +710,9 @@ func scancel() *cobra.Command {
 		},
 	}
 	cmd.SetVersionTemplate(util.VersionTemplate())
-	// Slurm uses -V for version; register it explicitly so that
-	// cobra does not bind version to the -v shorthand.
+	// Slurm uses -V for version and -v for verbose.
 	cmd.Flags().BoolP("version", "V", false, "version for scancel")
+	cmd.Flags().BoolVarP(&FlagVerbose, "verbose", "v", false, "")
 
 	addConfigPathFlag(cmd, &FlagConfigFilePath)
 	cmd.Flags().StringVarP(&FlagJobName, "name", "n", "",
@@ -726,8 +747,7 @@ func sbatch() *cobra.Command {
 			// Slurm uses -V for version and -v for verbose.
 			cbatch.RootCmd.Flags().BoolP("version", "V", false, "version for sbatch")
 			for i, arg := range args {
-				// Slurm allows repeated -v options such as -vv.
-				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
+				if isSlurmVerboseArg(arg) {
 					args[i] = "--verbose"
 				} else if (arg == "-t" || arg == "--time") && i+1 < len(args) {
 					args[i+1] = cbatch.ConvertSlurmTimeFormat(args[i+1])
@@ -798,6 +818,14 @@ func normalizeScontrolArgs(args []string) []string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if strings.HasPrefix(arg, "-") {
+			// Slurm uses -V for version and -v for verbose.
+			if isSlurmVerboseArg(arg) || arg == "--verbose" {
+				log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
+				continue
+			}
+			if arg == "-V" {
+				arg = "--version"
+			}
 			convertedArgs = append(convertedArgs, arg)
 			if wrapperFlagConsumesValue(arg) && i+1 < len(args) {
 				convertedArgs = append(convertedArgs, args[i+1])
@@ -1007,6 +1035,7 @@ func seff() *cobra.Command {
 }
 
 func sinfo() *cobra.Command {
+	var FlagVerbose bool
 	cmd := &cobra.Command{
 		Use:     "sinfo",
 		Short:   "View node and partition information",
@@ -1014,14 +1043,17 @@ func sinfo() *cobra.Command {
 		GroupID: "slurm",
 		Version: util.Version(),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if FlagVerbose {
+				log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
+			}
 			cinfo.RootCmd.PersistentPreRun(cmd, args)
 			return cinfo.RootCmd.RunE(cmd, args)
 		},
 	}
 	cmd.SetVersionTemplate(util.VersionTemplate())
-	// Slurm uses -V for version; register it explicitly so that
-	// cobra does not bind version to the -v shorthand.
+	// Slurm uses -V for version and -v for verbose.
 	cmd.Flags().BoolP("version", "V", false, "version for sinfo")
+	cmd.Flags().BoolVarP(&FlagVerbose, "verbose", "v", false, "")
 
 	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	// cmd.Flags().BoolVarP(&cinfo.FlagSummarize, "summarize", "s", false,
@@ -1056,10 +1088,14 @@ func squeue() *cobra.Command {
 		DisableFlagParsing: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cqueue.RootCmd.Use = "squeue [flags]"
+			// Slurm uses -V for version and -v for verbose.
+			cqueue.RootCmd.Flags().BoolP("version", "V", false, "version for squeue")
 			convertedArgs := make([]string, 0, len(args))
 			for i := 0; i < len(args); i++ {
 				arg := args[i]
 				switch {
+				case isSlurmVerboseArg(arg) || arg == "--verbose":
+					log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
 				case arg == "-h":
 					convertedArgs = append(convertedArgs, "-N")
 				case arg == "--jobs":
@@ -1246,9 +1282,15 @@ func sreport() *cobra.Command {
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			creport.RootCmd.Use = "sreport"
+			// Slurm uses -V for version and -v for verbose.
+			creport.RootCmd.Flags().BoolP("version", "V", false, "version for sreport")
 			convertedArgs := make([]string, 0, len(args))
 			normalizeCommandToken := true
 			for _, arg := range args {
+				if isSlurmVerboseArg(arg) || arg == "--verbose" {
+					log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
+					continue
+				}
 				if strings.Contains(arg, "=") && !strings.HasPrefix(arg, "-") {
 					log.Warningf("Slurm-style key=value argument %q is not supported in sreport wrapper. "+
 						"Please use sreport with explicit flags, e.g. --start-time/--end-time.", arg)
@@ -1294,8 +1336,7 @@ func srun() *cobra.Command {
 			// Slurm uses -V for version and -v for verbose.
 			crun.RootCmd.Flags().BoolP("version", "V", false, "version for srun")
 			for i, arg := range args {
-				// Slurm allows repeated -v options such as -vv.
-				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
+				if isSlurmVerboseArg(arg) {
 					args[i] = "--verbose"
 				}
 			}

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -710,9 +710,13 @@ func sbatch() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cbatch.RootCmd.Use = "sbatch [flags] file"
 			cbatch.RootCmd.InitDefaultHelpFlag()
-			cbatch.RootCmd.InitDefaultVersionFlag()
+			// Slurm uses -V for version and -v for verbose.
+			cbatch.RootCmd.Flags().BoolP("version", "V", false, "version for sbatch")
 			for i, arg := range args {
-				if (arg == "-t" || arg == "--time") && i+1 < len(args) {
+				// Slurm allows repeated -v options such as -vv.
+				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
+					args[i] = "--verbose"
+				} else if (arg == "-t" || arg == "--time") && i+1 < len(args) {
 					args[i+1] = cbatch.ConvertSlurmTimeFormat(args[i+1])
 				} else if strings.HasPrefix(arg, "--time=") {
 					args[i] = "--time=" + cbatch.ConvertSlurmTimeFormat(strings.TrimPrefix(arg, "--time="))
@@ -742,6 +746,7 @@ func sbatch() *cobra.Command {
 	}
 	// not implement feature:
 	cmd.Flags().BoolVar(&cbatch.FlagParsable, "parsable", false, "")
+	cmd.Flags().BoolVarP(&cbatch.FlagVerbose, "verbose", "v", false, "")
 	cmd.Flags().StringVar(&cbatch.FlagNTasksPerSocket, "ntasks-per-socket", "", "")
 	cmd.Flags().StringVar(&cbatch.FlagCpuFreq, "cpu-freq", "", "")
 	cmd.Flags().StringVar(&cbatch.FlagPriority, "priority", "", "")
@@ -1001,6 +1006,9 @@ func sinfo() *cobra.Command {
 		},
 	}
 	cmd.SetVersionTemplate(util.VersionTemplate())
+	// Slurm uses -V for version; register it explicitly so that
+	// cobra does not bind version to the -v shorthand.
+	cmd.Flags().BoolP("version", "V", false, "version for sinfo")
 
 	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	// cmd.Flags().BoolVarP(&cinfo.FlagSummarize, "summarize", "s", false,
@@ -1048,12 +1056,21 @@ func squeue() *cobra.Command {
 				case arg == "-o" || arg == "--format":
 					convertedArgs = append(convertedArgs, arg)
 					if i+1 < len(args) {
-						convertedArgs = append(convertedArgs, convertSqueueFormat(args[i+1]))
+						converted, err := convertSqueueFormat(args[i+1])
+						if err != nil {
+							log.Error(err)
+							os.Exit(util.ErrorCmdArg)
+						}
+						convertedArgs = append(convertedArgs, converted)
 						i++
 					}
 				case strings.HasPrefix(arg, "--format="):
-					convertedArgs = append(convertedArgs,
-						"--format="+convertSqueueFormat(strings.TrimPrefix(arg, "--format=")))
+					converted, err := convertSqueueFormat(strings.TrimPrefix(arg, "--format="))
+					if err != nil {
+						log.Error(err)
+						os.Exit(util.ErrorCmdArg)
+					}
+					convertedArgs = append(convertedArgs, "--format="+converted)
 				default:
 					convertedArgs = append(convertedArgs, arg)
 				}
@@ -1138,31 +1155,58 @@ Example: --format "%.5jobid %.20n %t" would output the job's ID with a minimum w
 
 var squeueFormatSpecRegex = regexp.MustCompile(`%(\.?\d*)([a-zA-Z]+)`)
 
-// Single-letter format specifiers that Slurm and cqueue assign different
-// meanings to. Letters sharing the same meaning need no entry.
+// Slurm single-letter format specifiers that cqueue supports with the same
+// meaning, mapped to their cqueue specifiers.
 var squeueFormatSpecMapping = map[string]string{
+	"a": "a", // account
+	"C": "C", // requested cpus
+	"D": "N", // number of nodes
 	"i": "j", // job id
 	"j": "n", // job name
-	"n": "r", // requested nodes
+	"k": "k", // comment
+	"l": "l", // time limit
 	"M": "e", // elapsed time
 	"m": "M", // requested memory per node
-	"D": "N", // number of nodes
 	"N": "L", // node list
+	"n": "r", // requested nodes
+	"o": "o", // command
+	"P": "P", // partition
+	"p": "p", // priority
+	"q": "q", // qos
+	"r": "R", // reason
+	"S": "S", // start time
 	"T": "t", // job state
+	"t": "t", // state
+	"u": "u", // user
+	"U": "U", // user id
 	"V": "s", // submit time
 }
 
 // convertSqueueFormat rewrites the Slurm single-letter format specifiers in a
 // format string to their cqueue equivalents. Multi-letter (cqueue-style)
-// specifiers and unmapped letters are left unchanged.
-func convertSqueueFormat(format string) string {
-	return squeueFormatSpecRegex.ReplaceAllStringFunc(format, func(spec string) string {
+// specifiers are passed through unchanged. Slurm specifiers that have no
+// cqueue field with the same meaning (e.g. %L time left, %e end time) are
+// rejected instead of silently displaying different data.
+func convertSqueueFormat(format string) (string, error) {
+	var invalid string
+	converted := squeueFormatSpecRegex.ReplaceAllStringFunc(format, func(spec string) string {
 		sub := squeueFormatSpecRegex.FindStringSubmatch(spec)
-		if converted, ok := squeueFormatSpecMapping[sub[2]]; ok {
-			return "%" + sub[1] + converted
+		if len(sub[2]) > 1 {
+			return spec
 		}
-		return spec
+		mapped, ok := squeueFormatSpecMapping[sub[2]]
+		if !ok {
+			if invalid == "" {
+				invalid = sub[2]
+			}
+			return spec
+		}
+		return "%" + sub[1] + mapped
 	})
+	if invalid != "" {
+		return "", fmt.Errorf("format specifier %%%s is not supported by cwrapper", invalid)
+	}
+	return converted, nil
 }
 
 func sreport() *cobra.Command {
@@ -1350,6 +1394,9 @@ func PrintSallocIgnoreDummyArgsMessage() {
 func PrintSbatchIgnoreArgsMessage() {
 	if cbatch.FlagParsable {
 		log.Warning("The feature --parsable is not yet supported by Crane, the use is ignored.")
+	}
+	if cbatch.FlagVerbose {
+		log.Warning("The feature --verbose/-v is not yet supported by Crane, the use is ignored.")
 	}
 	if cbatch.FlagNTasksPerSocket != "" {
 		log.Warning("The feature --ntasks-per-socket is not yet supported by Crane, the use is ignored.")

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -585,8 +585,11 @@ func salloc() *cobra.Command {
 			calloc.RootCmd.Use = "salloc"
 			// Add --help from calloc
 			calloc.RootCmd.InitDefaultHelpFlag()
+			// Slurm uses -V for version and -v for verbose.
+			calloc.RootCmd.Flags().BoolP("version", "V", false, "version for salloc")
 			for i, arg := range args {
-				if arg == "-v" {
+				// Slurm allows repeated -v options such as -vv.
+				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
 					args[i] = "--verbose"
 				}
 			}
@@ -599,6 +602,10 @@ func salloc() *cobra.Command {
 			args = calloc.RootCmd.Flags().Args()
 			if help, err := calloc.RootCmd.Flags().GetBool("help"); err != nil || help {
 				return calloc.RootCmd.Help()
+			}
+			if version, err := calloc.RootCmd.Flags().GetBool("version"); err == nil && version {
+				fmt.Println(util.Version())
+				return nil
 			}
 
 			PrintSallocIgnoreDummyArgsMessage()
@@ -635,6 +642,7 @@ func scancel() *cobra.Command {
 		Short:   "Cancel jobs",
 		Long:    "",
 		GroupID: "slurm",
+		Version: util.Version(),
 		Run: func(cmd *cobra.Command, args []string) {
 			// scancel uses spaced arguments,
 			// we need to convert it into a comma-separated list.
@@ -680,6 +688,11 @@ func scancel() *cobra.Command {
 			}
 		},
 	}
+	cmd.SetVersionTemplate(util.VersionTemplate())
+	// Slurm uses -V for version; register it explicitly so that
+	// cobra does not bind version to the -v shorthand.
+	cmd.Flags().BoolP("version", "V", false, "version for scancel")
+
 	addConfigPathFlag(cmd, &FlagConfigFilePath)
 	cmd.Flags().StringVarP(&FlagJobName, "name", "n", "",
 		"Cancel jobs with the specified job name")
@@ -1278,8 +1291,11 @@ func srun() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			crun.RootCmd.Use = "srun [flags] executable"
 			crun.RootCmd.InitDefaultHelpFlag()
+			// Slurm uses -V for version and -v for verbose.
+			crun.RootCmd.Flags().BoolP("version", "V", false, "version for srun")
 			for i, arg := range args {
-				if arg == "-v" {
+				// Slurm allows repeated -v options such as -vv.
+				if len(arg) > 1 && strings.TrimRight(arg, "v") == "-" {
 					args[i] = "--verbose"
 				}
 			}
@@ -1291,6 +1307,10 @@ func srun() *cobra.Command {
 			args = crun.RootCmd.Flags().Args()
 			if help, err := crun.RootCmd.Flags().GetBool("help"); err != nil || help {
 				return crun.RootCmd.Help()
+			}
+			if version, err := crun.RootCmd.Flags().GetBool("version"); err == nil && version {
+				fmt.Println(util.Version())
+				return nil
 			}
 			PrintSrunIgnoreDummyArgsMessage()
 			crun.RootCmd.PersistentPreRun(cmd, args)

--- a/internal/cwrapper/slurm.go
+++ b/internal/cwrapper/slurm.go
@@ -712,7 +712,7 @@ func scancel() *cobra.Command {
 	cmd.SetVersionTemplate(util.VersionTemplate())
 	// Slurm uses -V for version and -v for verbose.
 	cmd.Flags().BoolP("version", "V", false, "version for scancel")
-	cmd.Flags().BoolVarP(&FlagVerbose, "verbose", "v", false, "")
+	cmd.Flags().BoolVar(&FlagVerbose, "verbose", false, "")
 
 	addConfigPathFlag(cmd, &FlagConfigFilePath)
 	cmd.Flags().StringVarP(&FlagJobName, "name", "n", "",
@@ -1023,6 +1023,7 @@ func seff() *cobra.Command {
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ceff.RootCmd.Use = "seff [flags] [job_id, ...]"
+			ceff.RootCmd.Flags().BoolP("version", "V", false, "version for seff")
 			wrapCeffLeafRunEOnce.Do(func() {
 				util.RunEWrapperForLeafCommand(ceff.RootCmd)
 			})
@@ -1053,7 +1054,7 @@ func sinfo() *cobra.Command {
 	cmd.SetVersionTemplate(util.VersionTemplate())
 	// Slurm uses -V for version and -v for verbose.
 	cmd.Flags().BoolP("version", "V", false, "version for sinfo")
-	cmd.Flags().BoolVarP(&FlagVerbose, "verbose", "v", false, "")
+	cmd.Flags().BoolVar(&FlagVerbose, "verbose", false, "")
 
 	addConfigPathFlag(cmd, &cinfo.FlagConfigFilePath)
 	// cmd.Flags().BoolVarP(&cinfo.FlagSummarize, "summarize", "s", false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--verbose` support for batch job submissions.
  - Expanded Slurm option compatibility, including GPU, memory, dependency, signal, hold, and requeue options.
  - Added support for converting common Slurm time formats.
  - Added `show config` to display the active configuration file.
  - Improved Slurm command formatting and validation, including accounting and queue format conversion.

- **Bug Fixes**
  - Improved handling of unsupported options and clearer argument errors.
  - Corrected verbose and version flag behavior across Slurm commands.
  - Preserved specific configuration errors for more accurate reporting.

- **Documentation**
  - Updated command-line help to document configuration inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->