### PR TITLE
feat: select node count for ntasks-only jobs

### DIFF
--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -379,7 +379,8 @@ func MainCalloc(cmd *cobra.Command, args []string) error {
 		Type:            protos.JobType_Interactive,
 		Uid:             uint32(uid),
 		Gid:             uint32(gid),
-		NodeNum:         0,
+		NodeNumMin:      0,
+		NodeNumMax:      0,
 		NtasksPerNode:   0,
 		Ntasks:          0,
 		RequeueIfFailed: false,
@@ -395,7 +396,8 @@ func MainCalloc(cmd *cobra.Command, args []string) error {
 		if FlagNodes == 0 {
 			return util.NewCraneErr(util.ErrorCmdArg, "Invalid argument: --nodes must be > 0")
 		}
-		job.NodeNum = FlagNodes
+		job.NodeNumMin = FlagNodes
+		job.NodeNumMax = FlagNodes
 	}
 	if cmd.Flags().Changed("ntasks-per-node") {
 		if FlagNtasksPerNode == 0 {

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -83,7 +83,8 @@ func BuildCbatchJob(cmd *cobra.Command, args []string, config *util.Config) (*pr
 
 	// Set default values
 	job.NtasksPerNode = 0
-	job.NodeNum = 0
+	job.NodeNumMin = 0
+	job.NodeNumMax = 0
 	job.Ntasks = 0
 	job.GetUserEnv = false
 	job.Env = make(map[string]string)
@@ -109,7 +110,8 @@ func BuildCbatchJob(cmd *cobra.Command, args []string, config *util.Config) (*pr
 		if FlagNodes == 0 {
 			return nil, fmt.Errorf("invalid argument: --nodes must be > 0")
 		}
-		job.NodeNum = FlagNodes
+		job.NodeNumMin = FlagNodes
+		job.NodeNumMax = FlagNodes
 	}
 	if cmd.Flags().Changed("cpus-per-task") {
 		cpuPerTask := float64(FlagCpuPerTask)
@@ -353,7 +355,8 @@ func applyScriptArgs(cmd *cobra.Command, cbatchArgs []CbatchArg, job *protos.Job
 			if num == 0 {
 				return fmt.Errorf("invalid argument: %s must be > 0 in script", arg.name)
 			}
-			job.NodeNum = uint32(num)
+			job.NodeNumMin = uint32(num)
+			job.NodeNumMax = uint32(num)
 		case "--cpus-per-task", "-c":
 			num, err := util.ParseFloatWithPrecision(arg.val, 10)
 			if err != nil {

--- a/internal/ccon/run.go
+++ b/internal/ccon/run.go
@@ -381,7 +381,7 @@ func applyStepResourceOptions(cmd *cobra.Command, f *Flags, step *protos.StepToC
 }
 
 // applySchedulingOptions applies cluster scheduling options to the job
-func applySchedulingOptions(f *Flags, job *protos.JobToCtld) error {
+func applySchedulingOptions(cmd *cobra.Command, f *Flags, job *protos.JobToCtld) error {
 	// Partition/queue assignment
 	if f.Crane.Partition != "" {
 		job.PartitionName = f.Crane.Partition
@@ -406,10 +406,16 @@ func applySchedulingOptions(f *Flags, job *protos.JobToCtld) error {
 		job.Qos = f.Crane.Qos
 	}
 
-	// Node allocation - validate parameters
-	job.NodeNum = f.Crane.Nodes
-	job.NtasksPerNode = f.Crane.NtasksPerNode
-	job.Ntasks = f.Crane.Ntasks
+	if flagChanged(cmd, "nodes") {
+		job.NodeNumMin = f.Crane.Nodes
+		job.NodeNumMax = f.Crane.Nodes
+	}
+	if flagChanged(cmd, "ntasks-per-node") {
+		job.NtasksPerNode = f.Crane.NtasksPerNode
+	}
+	if flagChanged(cmd, "ntasks") {
+		job.Ntasks = f.Crane.Ntasks
+	}
 
 	// Node list (specific nodes)
 	if f.Crane.Nodelist != "" {
@@ -635,7 +641,8 @@ func buildContainerJob(cmd *cobra.Command, f *Flags, image string, command []str
 	job := &protos.JobToCtld{
 		Type:          protos.JobType_Container,
 		TimeLimit:     util.InvalidDuration(),
-		NodeNum:       0,
+		NodeNumMin:    0,
+		NodeNumMax:    0,
 		NtasksPerNode: 0,
 		Ntasks:        0,
 		GetUserEnv:    false,
@@ -646,7 +653,7 @@ func buildContainerJob(cmd *cobra.Command, f *Flags, image string, command []str
 		return nil, fmt.Errorf("failed to apply resource options: %v", err)
 	}
 
-	if err := applySchedulingOptions(f, job); err != nil {
+	if err := applySchedulingOptions(cmd, f, job); err != nil {
 		return nil, fmt.Errorf("failed to apply scheduling options: %v", err)
 	}
 

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -1482,7 +1482,8 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 			Type:            protos.JobType_Interactive,
 			Uid:             uint32(os.Getuid()),
 			Gid:             gids[0],
-			NodeNum:         0,
+			NodeNumMin:      0,
+			NodeNumMax:      0,
 			NtasksPerNode:   0,
 			Ntasks:          0,
 			RequeueIfFailed: false,
@@ -1546,7 +1547,8 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 			if FlagNodes == 0 {
 				return util.NewCraneErr(util.ErrorCmdArg, "Invalid argument: --nodes must be > 0")
 			}
-			job.NodeNum = FlagNodes
+			job.NodeNumMin = FlagNodes
+			job.NodeNumMax = FlagNodes
 		}
 		if cmd.Flags().Changed(NtasksPerNodeOptionStr) {
 			if FlagNtasksPerNode == 0 {

--- a/internal/crun/env.go
+++ b/internal/crun/env.go
@@ -95,7 +95,8 @@ func SetFieldsFromEnv(job *protos.JobToCtld, step *protos.StepToCtld) error {
 				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_JOB_NUM_NODES from env")
 			}
 			if job != nil {
-				job.NodeNum = uint32(numNodes)
+				job.NodeNumMin = uint32(numNodes)
+				job.NodeNumMax = uint32(numNodes)
 			} else {
 				step.NodeNum = uint32(numNodes)
 			}

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -805,32 +805,46 @@ func CheckJobArgs(job *protos.JobToCtld) error {
 		return fmt.Errorf("--mem and --mem-per-cpu are mutually exclusive, " +
 			"please check your command line options, submission script, and environment variables")
 	}
-	if job.NodeNum == 0 {
+
+	if job.NodeNumMin == 0 {
 		if job.Ntasks == 0 {
 			if job.NtasksPerNode == 0 {
 				job.Ntasks = 1
+				job.NtasksPerNode = 1
 			} else {
 				job.Ntasks = job.NtasksPerNode
 			}
 		}
 		if job.NtasksPerNode == 0 {
-			job.NodeNum = 1
+			job.NtasksPerNode = job.Ntasks
+			job.NodeNumMin = 1
+			job.NodeNumMax = job.Ntasks
 		} else {
-			job.NodeNum = (job.Ntasks-1)/job.NtasksPerNode + 1
+			job.NodeNumMin = (job.Ntasks-1)/job.NtasksPerNode + 1
+			job.NodeNumMax = job.NodeNumMin
 		}
 	}
+
 	if job.Ntasks == 0 {
 		if job.NtasksPerNode == 0 {
-			job.Ntasks = job.NodeNum
+			job.Ntasks = job.NodeNumMin
 		} else {
-			job.Ntasks = job.NodeNum * job.NtasksPerNode
+			job.Ntasks = job.NodeNumMin * job.NtasksPerNode
 		}
 	}
-	if job.NodeNum > job.Ntasks {
-		log.Warnf("Warning: can't run %d tasks on %d nodes, setting NodeNum to ntasks.", job.Ntasks, job.NodeNum)
-		job.NodeNum = job.Ntasks
+
+	if job.NodeNumMax == 0 {
+		job.NodeNumMax = job.NodeNumMin
 	}
-	if job.NtasksPerNode > 0 && job.NtasksPerNode*job.NodeNum < job.Ntasks {
+	if job.NodeNumMin > job.Ntasks {
+		log.Warnf("Warning: can't run %d tasks on %d nodes, setting NodeNum to ntasks.", job.Ntasks, job.NodeNumMin)
+		job.NodeNumMin = job.Ntasks
+		job.NodeNumMax = job.Ntasks
+	} else if job.NodeNumMax > job.Ntasks {
+		log.Warnf("Warning: can't run %d tasks on up to %d nodes, setting NodeNumMax to ntasks.", job.Ntasks, job.NodeNumMax)
+		job.NodeNumMax = job.Ntasks
+	}
+	if job.NtasksPerNode > 0 && job.NtasksPerNode*job.NodeNumMax < job.Ntasks {
 		return fmt.Errorf("invalid argument: NtasksPerNode * NodeNum < Ntasks, unable to allocate resources")
 	}
 	if job.CpusPerTask != nil && *job.CpusPerTask <= 0 {
@@ -839,7 +853,7 @@ func CheckJobArgs(job *protos.JobToCtld) error {
 	if err := CheckJobNameLength(job.Name); err != nil {
 		return err
 	}
-	if job.NodeNum <= 0 {
+	if job.NodeNumMin <= 0 {
 		return fmt.Errorf("--nodes must > 0")
 	}
 	if job.TimeLimit.AsDuration() <= 0 {

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -200,7 +200,7 @@ message JobToCtld {
   string account = 6;
   string name = 7;
   string qos = 8;
-  uint32 node_num = 9;
+  uint32 node_num_min = 9;
   uint32 ntasks_per_node = 10;
   uint32 ntasks = 17;
 
@@ -258,6 +258,7 @@ message JobToCtld {
   optional uint64 mem_per_node = 51;
   optional GresMap gres_per_node = 52;
   bool no_requeue = 53;
+  uint32 node_num_max = 54;
 
   // Array submission spec for this job. Child identity is runtime-only.
   ArraySpec array_spec = 58;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job requests now support separate minimum and maximum node counts.
  * The `--nodes` option sets both node-count limits consistently across interactive, batch, and container jobs.
  * Node requirements from environment settings and script arguments are applied consistently.

* **Bug Fixes**
  * Scheduling options are now applied only when explicitly provided.
  * Node-count validation now correctly enforces minimum and maximum limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->