### PR TITLE
fix: cacctmgr/ccontrol --help

### DIFF
--- a/internal/cacctmgr/help.go
+++ b/internal/cacctmgr/help.go
@@ -309,7 +309,7 @@ func showHelp() {
 	--config, -C            Specify config file path (default: /etc/crane/config.yaml)
 	--plugin-config, -p     Specify plugin config file path (default: /etc/crane/plugin.yaml)
 	--json, -J              Format output as JSON
-	-V, --version           Display program version
+	--version, -v           Display program version
 	--force, -f             Force operation without confirmation
 	--partition-limit, -P   Display partition resource limits (for show account/user)
 

--- a/internal/ccontrol/help.go
+++ b/internal/ccontrol/help.go
@@ -136,7 +136,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
   --help, -h     Display this help message
-  -V, --version  Show version information
+  --version, -v  Show version information
   --json, -J     Format output as JSON
   --config, -C   Specify an alternative configuration file
   


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line help text to display the version option consistently as `--version, -v`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->