### PR TITLE
feat: submit unified execution GID lists

### DIFF
--- a/internal/calloc/calloc.go
+++ b/internal/calloc/calloc.go
@@ -359,8 +359,10 @@ func MainCalloc(cmd *cobra.Command, args []string) error {
 		return util.WrapCraneErr(util.ErrorSystem, "Failed to get current user: %s", err)
 	}
 
-	// Get egid using os.Getgid() instead of using user.Current()
-	gid := os.Getgid()
+	gids, err := util.CollectEffectiveGroups()
+	if err != nil {
+		return util.WrapCraneErr(util.ErrorSystem, "%s", err)
+	}
 
 	uid, err := strconv.Atoi(gVars.user.Uid)
 	if err != nil {
@@ -378,7 +380,7 @@ func MainCalloc(cmd *cobra.Command, args []string) error {
 		PartitionName:   "",
 		Type:            protos.JobType_Interactive,
 		Uid:             uint32(uid),
-		Gid:             uint32(gid),
+		Gids:            gids,
 		NodeNumMin:      0,
 		NodeNumMax:      0,
 		NtasksPerNode:   0,

--- a/internal/cbatch/cbatch.go
+++ b/internal/cbatch/cbatch.go
@@ -49,6 +49,11 @@ var (
 // BuildCbatchJob reads flags and script file to build a job
 func BuildCbatchJob(cmd *cobra.Command, args []string, config *util.Config) (*protos.JobToCtld, error) {
 	job := new(protos.JobToCtld)
+	gids, err := util.CollectEffectiveGroups()
+	if err != nil {
+		return nil, err
+	}
+	job.Gids = gids
 	warnUnsupportedCLIFlags(cmd)
 
 	// Parse the script file or use wrapped script

--- a/internal/cbatch/cmd.go
+++ b/internal/cbatch/cmd.go
@@ -125,7 +125,6 @@ var (
 			}
 
 			job.Uid = uint32(os.Getuid())
-			job.Gid = uint32(os.Getgid())
 			job.CmdLine = strings.Join(os.Args, " ")
 
 			// Process the content of --get-user-env

--- a/internal/cbatch/pod.go
+++ b/internal/cbatch/pod.go
@@ -159,7 +159,7 @@ func parsePodPortMapping(portSpec string, ports *[]*protos.PodJobAdditionalMeta_
 
 func validatePodMeta(job *protos.JobToCtld, meta *protos.PodJobAdditionalMeta) error {
 	if job.Uid != 0 && !meta.Userns {
-		if meta.RunAsUser != job.Uid || meta.RunAsGroup != job.Gid {
+		if len(job.Gids) == 0 || meta.RunAsUser != job.Uid || meta.RunAsGroup != job.Gids[0] {
 			return fmt.Errorf("with --pod-userns=false, only current user and accessible groups are allowed")
 		}
 	}
@@ -182,9 +182,33 @@ func buildPodMeta(job *protos.JobToCtld, podOpts *podOptions) (*protos.PodJobAdd
 		if err := parsePodUser(podOpts.user, podMeta); err != nil {
 			return nil, err
 		}
-	} else if !podMeta.Userns {
+		if strings.Contains(podOpts.user, ":") {
+			gids, err := util.CollectGroupsForUser(podMeta.RunAsUser, podMeta.RunAsGroup)
+			if err != nil {
+				return nil, err
+			}
+			job.Gids = gids
+		} else {
+			gids, err := util.CollectDefaultGroupsForUser(podMeta.RunAsUser)
+			if err != nil {
+				return nil, err
+			}
+			job.Gids = gids
+			podMeta.RunAsGroup = gids[0]
+		}
+	} else if podMeta.Userns {
+		gids, err := util.CollectDefaultGroupsForUser(podMeta.RunAsUser)
+		if err != nil {
+			return nil, err
+		}
+		job.Gids = gids
+		podMeta.RunAsGroup = gids[0]
+	} else {
 		podMeta.RunAsUser = uint32(os.Getuid())
-		podMeta.RunAsGroup = uint32(os.Getgid())
+		if len(job.Gids) == 0 {
+			return nil, fmt.Errorf("effective group list is empty")
+		}
+		podMeta.RunAsGroup = job.Gids[0]
 	}
 
 	for _, port := range podOpts.ports {

--- a/internal/ccon/run.go
+++ b/internal/ccon/run.go
@@ -473,7 +473,11 @@ func applyEnvironmentOptions(_ *Flags, job *protos.JobToCtld) error {
 
 	// Set UID/GID for job execution
 	job.Uid = uint32(os.Getuid())
-	job.Gid = uint32(os.Getgid())
+	gids, err := util.CollectEffectiveGroups()
+	if err != nil {
+		return fmt.Errorf("failed to collect effective groups: %w", err)
+	}
+	job.Gids = gids
 
 	// Set command line for auditing
 	job.CmdLine = strings.Join(os.Args, " ")
@@ -493,6 +497,14 @@ func applyStepEnvironmentOptions(step *protos.StepToCtld) error {
 
 	if step.Uid == 0 {
 		step.Uid = uint32(os.Getuid())
+	}
+
+	if len(step.Gids) == 0 {
+		gids, err := util.CollectEffectiveGroups()
+		if err != nil {
+			return fmt.Errorf("failed to collect effective groups: %w", err)
+		}
+		step.Gids = gids
 	}
 
 	return nil
@@ -609,9 +621,33 @@ func buildPodMeta(_ *cobra.Command, f *Flags, job *protos.JobToCtld) (*protos.Po
 		if err := parseUserSpec(f.Run.User, podMeta); err != nil {
 			return nil, fmt.Errorf("invalid user specification '%s': %v", f.Run.User, err)
 		}
-	} else if !podMeta.Userns {
+		if strings.Contains(f.Run.User, ":") {
+			gids, err := util.CollectGroupsForUser(podMeta.RunAsUser, podMeta.RunAsGroup)
+			if err != nil {
+				return nil, fmt.Errorf("failed to collect requested user groups: %w", err)
+			}
+			job.Gids = gids
+		} else {
+			gids, err := util.CollectDefaultGroupsForUser(podMeta.RunAsUser)
+			if err != nil {
+				return nil, fmt.Errorf("failed to collect requested user groups: %w", err)
+			}
+			job.Gids = gids
+			podMeta.RunAsGroup = gids[0]
+		}
+	} else if podMeta.Userns {
+		gids, err := util.CollectDefaultGroupsForUser(podMeta.RunAsUser)
+		if err != nil {
+			return nil, fmt.Errorf("failed to collect container user groups: %w", err)
+		}
+		job.Gids = gids
+		podMeta.RunAsGroup = gids[0]
+	} else {
+		if len(job.Gids) == 0 {
+			return nil, fmt.Errorf("effective group list is empty")
+		}
 		podMeta.RunAsUser = job.Uid
-		podMeta.RunAsGroup = job.Gid
+		podMeta.RunAsGroup = job.Gids[0]
 	}
 
 	if networkMode == protos.PodJobAdditionalMeta_NODE && len(f.Run.Ports) != 0 {
@@ -751,7 +787,7 @@ func validateContainerJob(job *protos.JobToCtld) error {
 	}
 
 	if job.Uid != 0 && !job.PodMeta.Userns {
-		if job.PodMeta.RunAsUser != job.Uid || job.PodMeta.RunAsGroup != job.Gid {
+		if len(job.Gids) == 0 || job.PodMeta.RunAsUser != job.Uid || job.PodMeta.RunAsGroup != job.Gids[0] {
 			return fmt.Errorf("with --userns=false, only current user and accessible groups are allowed")
 		}
 	}

--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -1641,17 +1641,9 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 
 	var job *protos.JobToCtld
 	var step *protos.StepToCtld
-	egid := syscall.Getegid()
-	groups, err := syscall.Getgroups()
+	gids, err := util.CollectEffectiveGroups()
 	if err != nil {
-		return util.NewCraneErr(util.ErrorSystem, fmt.Sprintf("Failed to get user groups: %s.", err))
-	}
-	gids := []uint32{uint32(egid)}
-
-	for _, g := range groups {
-		if g != egid {
-			gids = append(gids, uint32(g))
-		}
+		return util.WrapCraneErr(util.ErrorSystem, "%s", err)
 	}
 
 	if jobMode {
@@ -1661,7 +1653,7 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 			PartitionName:   "",
 			Type:            protos.JobType_Interactive,
 			Uid:             uint32(os.Getuid()),
-			Gid:             gids[0],
+			Gids:            gids,
 			NodeNumMin:      0,
 			NodeNumMax:      0,
 			NtasksPerNode:   0,
@@ -1686,7 +1678,7 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 			JobId:           jobId,
 			Type:            protos.JobType_Interactive,
 			Uid:             uint32(os.Getuid()),
-			Gid:             gids,
+			Gids:            gids,
 			NodeNum:         0,
 			NtasksPerNode:   0,
 			Ntasks:          0,

--- a/internal/util/groups.go
+++ b/internal/util/groups.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+const maxExecutionGroups = 256
+
+func normalizeExecutionGroups(egid int, groups []int) ([]uint32, error) {
+	if egid < 0 {
+		return nil, fmt.Errorf("failed to get effective group: %d", egid)
+	}
+	if len(groups) >= maxExecutionGroups {
+		return nil, fmt.Errorf("group list exceeds maximum size of %d", maxExecutionGroups)
+	}
+
+	result := make([]uint32, 0, len(groups)+1)
+	seen := make(map[uint32]struct{}, len(groups)+1)
+	appendGroup := func(group int) {
+		gid := uint32(group)
+		if _, exists := seen[gid]; exists {
+			return
+		}
+		seen[gid] = struct{}{}
+		result = append(result, gid)
+	}
+
+	appendGroup(egid)
+	for _, group := range groups {
+		if group < 0 {
+			return nil, fmt.Errorf("invalid supplementary group: %d", group)
+		}
+		appendGroup(group)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("effective group list is empty")
+	}
+	return result, nil
+}
+
+// CollectEffectiveGroups returns the caller's effective group followed by its
+// supplementary groups.  The effective group is authoritative for the first
+// protocol element; supplementary groups are deduplicated while preserving
+// the kernel-provided order.
+func CollectEffectiveGroups() ([]uint32, error) {
+	egid := syscall.Getegid()
+	groups, err := syscall.Getgroups()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get supplementary groups: %w", err)
+	}
+	return normalizeExecutionGroups(egid, groups)
+}
+
+// CollectGroupsForUser resolves the requested user's supplementary groups
+// through NSS. The requested primary GID is always emitted first; the
+// backend performs the final node-local authorization and intersection.
+func CollectGroupsForUser(uid, primary uint32) ([]uint32, error) {
+	target, err := lookupUser(uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target user %d: %w", uid, err)
+	}
+	return collectGroupsForLookup(target, uid, primary)
+}
+
+// CollectDefaultGroupsForUser resolves a user's passwd primary group and
+// returns it before the supplementary groups. It is used when a container
+// selects a target UID without an explicit GID.
+func CollectDefaultGroupsForUser(uid uint32) ([]uint32, error) {
+	target, err := lookupUser(uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target user %d: %w", uid, err)
+	}
+	primary, err := strconv.ParseUint(target.Gid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid primary NSS group %q for user %d: %w", target.Gid, uid, err)
+	}
+	return collectGroupsForLookup(target, uid, uint32(primary))
+}
+
+func lookupUser(uid uint32) (*user.User, error) {
+	return user.LookupId(strconv.FormatUint(uint64(uid), 10))
+}
+
+func collectGroupsForLookup(target *user.User, uid, primary uint32) ([]uint32, error) {
+	groupIDs, err := target.GroupIds()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve groups for user %d: %w", uid, err)
+	}
+	groups := make([]int, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		gid, err := strconv.ParseUint(groupID, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid NSS group %q for user %d: %w", groupID, uid, err)
+		}
+		groups = append(groups, int(gid))
+	}
+	return normalizeExecutionGroups(int(primary), groups)
+}

--- a/internal/util/groups_test.go
+++ b/internal/util/groups_test.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"os/user"
+	"strconv"
+	"testing"
+)
+
+func TestNormalizeExecutionGroups(t *testing.T) {
+	got, err := normalizeExecutionGroups(100, []int{200, 100, 300, 200})
+	if err != nil {
+		t.Fatalf("normalizeExecutionGroups() error = %v", err)
+	}
+	want := []uint32{100, 200, 300}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestNormalizeExecutionGroupsRejectsInvalidInput(t *testing.T) {
+	if _, err := normalizeExecutionGroups(100, []int{-1}); err == nil {
+		t.Fatal("expected a negative supplementary GID to be rejected")
+	}
+	tooMany := make([]int, maxExecutionGroups)
+	if _, err := normalizeExecutionGroups(100, tooMany); err == nil {
+		t.Fatal("expected an oversized group list to be rejected")
+	}
+}
+
+func TestCollectGroupsForUserUsesRequestedPrimary(t *testing.T) {
+	current, err := user.Current()
+	if err != nil {
+		t.Skipf("current user is unavailable: %v", err)
+	}
+	uid, err := strconv.ParseUint(current.Uid, 10, 32)
+	if err != nil {
+		t.Fatalf("invalid current UID %q: %v", current.Uid, err)
+	}
+	gid, err := strconv.ParseUint(current.Gid, 10, 32)
+	if err != nil {
+		t.Fatalf("invalid current GID %q: %v", current.Gid, err)
+	}
+
+	groups, err := CollectGroupsForUser(uint32(uid), uint32(gid))
+	if err != nil {
+		t.Fatalf("CollectGroupsForUser() error = %v", err)
+	}
+	if len(groups) == 0 || groups[0] != uint32(gid) {
+		t.Fatalf("CollectGroupsForUser() = %v, primary GID %d is not first", groups, gid)
+	}
+}
+
+func TestCollectGroupsForUserRejectsUnknownUser(t *testing.T) {
+	if _, err := CollectGroupsForUser(^uint32(0), 0); err == nil {
+		t.Fatal("expected an unknown target UID to be rejected")
+	}
+}

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -207,7 +207,8 @@ message JobToCtld {
   bool requeue_if_failed = 12;
   bool get_user_env = 13;
 
-  uint32 gid = 14;  // egid
+  // Ordered execution groups: effective GID first, supplementary groups after.
+  repeated uint32 gids = 14;
 
   Dependencies dependencies = 15;
 
@@ -323,7 +324,8 @@ message StepToCtld {
   bool requeue_if_failed = 12;
   bool get_user_env = 13;
 
-  repeated uint32 gid = 14;
+  // Ordered execution groups: effective GID first, supplementary groups after.
+  repeated uint32 gids = 14;
 
   uint32 ntasks = 15;
 
@@ -425,7 +427,8 @@ message StepToD {
   StepType step_type = 5;
 
   uint32 uid = 6;
-  repeated uint32 gid = 7;
+  // Ordered execution groups: effective GID first, supplementary groups after.
+  repeated uint32 gids = 7;
   map<uint32 /*task id*/, ResourceInNodeV3> task_res_map = 8;
 
   // For execution step


### PR DESCRIPTION
## Summary
- add shared group collection helper with effective GID first
- propagate complete ordered GID lists through cbatch, calloc, crun, and ccon job/step requests
- resolve explicit container `uid:gid` group lists through NSS and reject incomplete requests
- add normalization and NSS error tests

## Contract
- `gids[0]` is the effective/primary GID
- `gids[1:]` are supplementary GIDs
- this is a breaking protocol change; deploy with the matching Backend PR and do not mix versions

## Validation
- `go test ./...`
- focused `go test -race ./internal/util ./internal/cbatch ./internal/ccon ./internal/crun ./internal/calloc`
- `gofmt` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Execution now preserves the caller’s effective group and supplementary group memberships.
  - Jobs and steps support ordered group lists, with the effective group listed first.
  - User-specific group memberships are resolved when running commands or creating pods.
- **Bug Fixes**
  - Improved user and group validation prevents execution with missing or invalid group information.
  - Group lookup and collection failures now return clear system errors instead of silently falling back to a single group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->