### PR TITLE
feat: Add future node

### DIFF
--- a/internal/ccontrol/output.go
+++ b/internal/ccontrol/output.go
@@ -254,10 +254,16 @@ func printNodeDetails(node *protos.CranedInfo) {
 	memInfo := formatMemInfo(node)
 	gresInfo := formatGresInfo(node)
 
+	featuresInfo := ""
+	if len(node.Features) > 0 {
+		featuresInfo = fmt.Sprintf("\tFeatures=%s\n", strings.Join(node.Features, ","))
+	}
+
 	fmt.Printf(
 		"NodeName=%v State=%v %s\n"+
 			"\t%s\n"+
 			"\t%s\n"+
+			"%s"+
 			"\tSockets=%d\n"+
 			"\tPartition=%s RunningJob=%d Version=%s\n"+
 			"\tOs=%s\n"+
@@ -266,6 +272,7 @@ func printNodeDetails(node *protos.CranedInfo) {
 		node.Hostname, stateStr, cpuInfo,
 		memInfo,
 		gresInfo,
+		featuresInfo,
 		node.GetNodeTopoInfo().GetSockets(),
 		strings.Join(node.PartitionNames, ","), node.RunningJobNum, cranedVersion,
 		cranedOs,
@@ -296,6 +303,10 @@ func formatNodeTimes(node *protos.CranedInfo) nodeTimes {
 func formatNodeState(node *protos.CranedInfo) string {
 	if util.IsSlurmOutputMode() {
 		return util.FormatSlurmNodeState(node.ResourceState, node.ControlState, node.PowerState)
+	}
+	if node.ResourceState == protos.CranedResourceState_CRANE_FUTURE {
+		// An unmapped FUTURE node has no craned attached, so no power state.
+		return "future"
 	}
 	stateStr := strings.ToLower(node.ResourceState.String()[6:])
 	if node.ControlState != protos.CranedControlState_CRANE_NONE {

--- a/internal/cinfo/cinfo.go
+++ b/internal/cinfo/cinfo.go
@@ -32,10 +32,11 @@ import (
 
 var (
 	resourceStateMap = map[string]protos.CranedResourceState{
-		"idle":  protos.CranedResourceState_CRANE_IDLE,
-		"mix":   protos.CranedResourceState_CRANE_MIX,
-		"alloc": protos.CranedResourceState_CRANE_ALLOC,
-		"down":  protos.CranedResourceState_CRANE_DOWN,
+		"idle":   protos.CranedResourceState_CRANE_IDLE,
+		"mix":    protos.CranedResourceState_CRANE_MIX,
+		"alloc":  protos.CranedResourceState_CRANE_ALLOC,
+		"down":   protos.CranedResourceState_CRANE_DOWN,
+		"future": protos.CranedResourceState_CRANE_FUTURE,
 	}
 
 	controlStateMap = map[string]protos.CranedControlState{
@@ -108,6 +109,7 @@ func ApplyResourceStateDefaults(states []protos.CranedResourceState) []protos.Cr
 		protos.CranedResourceState_CRANE_MIX,
 		protos.CranedResourceState_CRANE_ALLOC,
 		protos.CranedResourceState_CRANE_DOWN,
+		protos.CranedResourceState_CRANE_FUTURE,
 	}
 }
 func ApplyControlStateDefaults(states []protos.CranedControlState) []protos.CranedControlState {

--- a/internal/cinfo/cmd.go
+++ b/internal/cinfo/cmd.go
@@ -74,7 +74,7 @@ func init() {
 		"Display the specified nodes only")
 	RootCmd.Flags().StringSliceVarP(&FlagFilterCranedStates, "states", "t", nil,
 		"Display nodes with the specified states only. \n"+
-			"The state can take IDLE, MIX, ALLOC, DOWN (case-insensitive). \n"+
+			"The state can take IDLE, MIX, ALLOC, DOWN, FUTURE (case-insensitive). \n"+
 			"Example: \n"+
 			"\t -t idle,mix \n"+
 			"\t -t=alloc \n")

--- a/internal/cinfo/output.go
+++ b/internal/cinfo/output.go
@@ -127,6 +127,11 @@ func ProcessState(flattened []FlattenedData, tableOutputCell [][]string) {
 		}
 
 		stateStr := strings.ToLower(strings.TrimPrefix(data.ResourceState.String(), "CRANE_"))
+		if data.ResourceState == protos.CranedResourceState_CRANE_FUTURE {
+			// An unmapped FUTURE node has no craned attached, so no power state.
+			tableOutputCell[idx] = append(tableOutputCell[idx], stateStr)
+			continue
+		}
 		if data.ControlState != protos.CranedControlState_CRANE_NONE {
 			controlState := strings.ToLower(strings.TrimPrefix(data.ControlState.String(), "CRANE_"))
 			stateStr += "(" + controlState + ")"
@@ -260,6 +265,10 @@ func BuildStateString(cranedList *protos.TrimmedPartitionInfo_TrimmedCranedInfo)
 			cranedList.ResourceState, cranedList.ControlState, cranedList.PowerState)
 	}
 	stateStr := strings.ToLower(strings.TrimPrefix(cranedList.ResourceState.String(), "CRANE_"))
+	if cranedList.ResourceState == protos.CranedResourceState_CRANE_FUTURE {
+		// An unmapped FUTURE node has no craned attached, so no power state.
+		return stateStr
+	}
 
 	if cranedList.ControlState != protos.CranedControlState_CRANE_NONE {
 		controlState := strings.ToLower(strings.TrimPrefix(cranedList.ControlState.String(), "CRANE_"))

--- a/protos/Crane.proto
+++ b/protos/Crane.proto
@@ -95,6 +95,19 @@ message UpdateTraceConfigReply {
   RuntimeTraceConfig config = 3;
 }
 
+message CranedMapFutureNodeRequest {
+  string hostname = 1;
+  uint32 cpu = 2;
+  uint64 memory_bytes = 3;
+  string feature = 4;
+}
+
+message CranedMapFutureNodeReply {
+  bool ok = 1;
+  string craned_id = 2;
+  string reason = 3;
+}
+
 message CranedRegisterRequest {
   string craned_id = 1;
   CranedRemoteMeta remote_meta = 2;
@@ -1783,6 +1796,7 @@ service CraneCtldForInternal {
   /* RPCs called from Craned */
   rpc StepStatusChange(StepStatusChangeRequest) returns (StepStatusChangeReply);
   rpc CranedTriggerReverseConn(CranedTriggerReverseConnRequest) returns (google.protobuf.Empty);
+  rpc CranedMapFutureNode(CranedMapFutureNodeRequest) returns (CranedMapFutureNodeReply);
   rpc CranedRegister(CranedRegisterRequest) returns (CranedRegisterReply);
   rpc CranedPing(CranedPingRequest) returns (CranedPingReply);
   rpc BroadcastPmixPort(BroadcastPmixPortRequest) returns (BroadcastPmixPortReply);

--- a/protos/PublicDefs.proto
+++ b/protos/PublicDefs.proto
@@ -82,6 +82,7 @@ enum CranedResourceState {
   CRANE_MIX = 1;
   CRANE_ALLOC = 2;
   CRANE_DOWN = 3;
+  CRANE_FUTURE = 4;
 }
 
 enum CranedPowerState {
@@ -786,6 +787,10 @@ message CranedInfo {
 
   // Physical CPU topology of this node.
   NodeTopoInfo node_topo_info = 17;
+
+  repeated string features = 18;
+  // True if this node is a FUTURE node mapped to a running craned.
+  bool dynamic_mapped = 19;
 }
 
 message ReservationInfo {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying and displaying nodes in the **FUTURE** state.
  - Added feature information to node details when available.
  - Added the ability to dynamically map future nodes using hostname, CPU, memory, and feature details.
  - Added indicators showing whether a future node has been dynamically mapped.

- **Improvements**
  - The node state filter now accepts **FUTURE**.
  - Future nodes now display simplified state information without unavailable power-state details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->