### PR TITLE
test: add make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ else
 endif
 
 # Targets
-.PHONY: all build protos clean install plugin plugin-monitor plugin-trace plugin-other tool service format package check-goreleaser
+.PHONY: all build test protos clean install plugin plugin-monitor plugin-trace plugin-other tool service format package check-goreleaser
 
 all: build plugin service
 
@@ -111,6 +111,10 @@ protos:
 	@mkdir -p ./generated/protos/supervisor && mv generated/protos/Supervisor*.go ./generated/protos/supervisor
 	@echo "  - Summary:"
 	@echo "    - Protobuf files generated in ./generated/protos/"
+
+test: protos
+	@echo "- Running Go tests..."
+	@$(GO) test ./...
 
 build: protos
 	@echo "- Building executables with $(GO_VERSION)..."


### PR DESCRIPTION
## Summary

- add a `make test` target to generate protobuf code and run all Go tests
- include the target in `.PHONY` declarations

## Verification

- `GOENV=off GOCACHE=/tmp/cranesched-frontend-go-build-cache CCACHE_DISABLE=1 make test`
- 10 packages with tests, 66 top-level tests, 181 test executions, all passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a test command that prepares protocol definitions and runs the full Go test suite.
  - Added a status message when tests begin running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->