### PR TITLE
fix: display terminal accounting times

### DIFF
--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -33,6 +33,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
@@ -42,6 +44,9 @@ var (
 const (
 	kTerminationSignalBase = 256
 	kCraneExitCodeBase     = 320
+	// Keep this aligned with google.protobuf.util.TimeUtil's timestamp max;
+	// the backend uses that exact second as the unset/future sentinel.
+	kAccountingMaxTimestampSeconds int64 = 253402300799
 )
 
 // QueryJob will query all pending, running and completed jobs.
@@ -313,6 +318,88 @@ type JobOrStep struct {
 	isStep   bool
 }
 
+type accountingTiming struct {
+	status    protos.JobStatus
+	elapsed   *durationpb.Duration
+	startTime *timestamppb.Timestamp
+	endTime   *timestamppb.Timestamp
+}
+
+func getAccountingTiming(item *JobOrStep) accountingTiming {
+	if item == nil {
+		return accountingTiming{}
+	}
+	if item.isStep {
+		if item.stepInfo == nil {
+			return accountingTiming{}
+		}
+		return accountingTiming{
+			status:    item.stepInfo.Status,
+			elapsed:   item.stepInfo.ElapsedTime,
+			startTime: item.stepInfo.StartTime,
+			endTime:   item.stepInfo.EndTime,
+		}
+	}
+	if item.job == nil {
+		return accountingTiming{}
+	}
+	return accountingTiming{
+		status:    item.job.Status,
+		elapsed:   item.job.ElapsedTime,
+		startTime: item.job.StartTime,
+		endTime:   item.job.EndTime,
+	}
+}
+
+func isTerminalAccountingStatus(status protos.JobStatus) bool {
+	switch status {
+	case protos.JobStatus_Completed,
+		protos.JobStatus_Failed,
+		protos.JobStatus_ExceedTimeLimit,
+		protos.JobStatus_Cancelled,
+		protos.JobStatus_OutOfMemory,
+		protos.JobStatus_Deadline:
+		return true
+	default:
+		return false
+	}
+}
+
+func validAccountingTime(timestamp *timestamppb.Timestamp) (time.Time, bool) {
+	if timestamp == nil || !timestamp.IsValid() ||
+		(timestamp.Seconds == 0 && timestamp.Nanos == 0) {
+		return time.Time{}, false
+	}
+	if timestamp.Seconds >= kAccountingMaxTimestampSeconds {
+		return time.Time{}, false
+	}
+	timestampTime := timestamp.AsTime()
+	accountingEpoch := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+	// The protobuf timestamp maximum is the backend's unset/future sentinel,
+	// not a real accounting event.
+	if timestampTime.Before(accountingEpoch) {
+		return time.Time{}, false
+	}
+	return timestampTime, true
+}
+
+func validElapsedSeconds(duration *durationpb.Duration) (int64, bool) {
+	if duration == nil || !duration.IsValid() || duration.Seconds < 0 ||
+		duration.Nanos < 0 {
+		return 0, false
+	}
+	return duration.Seconds, true
+}
+
+func formatAccountingTime(timestamp *timestamppb.Timestamp,
+	requirePast bool) string {
+	value, ok := validAccountingTime(timestamp)
+	if !ok || (requirePast && value.After(time.Now())) {
+		return "unknown"
+	}
+	return value.In(time.Local).Format("2006-01-02 15:04:05")
+}
+
 type FieldProcessor struct {
 	header  string
 	process func(item *JobOrStep) string
@@ -350,52 +437,41 @@ func ProcessAllocCPUs(item *JobOrStep) string {
 
 // ElapsedTime (D)
 func ProcessElapsedTime(item *JobOrStep) string {
-	var status protos.JobStatus
-	var startTime, endTime time.Time
-	if item.isStep {
-		status = item.stepInfo.Status
-		if item.stepInfo.StartTime == nil || item.stepInfo.EndTime == nil {
-			return ""
+	timing := getAccountingTiming(item)
+	if timing.status == protos.JobStatus_Running {
+		if seconds, ok := validElapsedSeconds(timing.elapsed); ok {
+			return util.SecondTimeFormat(seconds)
 		}
-		startTime = item.stepInfo.StartTime.AsTime()
-		endTime = item.stepInfo.EndTime.AsTime()
-	} else {
-		status = item.job.Status
-		if item.job.StartTime == nil || item.job.EndTime == nil {
-			return ""
-		}
-		startTime = item.job.StartTime.AsTime()
-		endTime = item.job.EndTime.AsTime()
+		return ""
+	}
+	if !isTerminalAccountingStatus(timing.status) {
+		return ""
 	}
 
-	if status == protos.JobStatus_Running {
-		if item.isStep {
-			return util.SecondTimeFormat(item.stepInfo.ElapsedTime.Seconds)
-		} else {
-			return util.SecondTimeFormat(item.job.ElapsedTime.Seconds)
-		}
-	} else if status == protos.JobStatus_Completed {
-		// Prefer backend elapsed time (already excludes suspended duration).
-		if item.isStep {
-			if item.stepInfo.ElapsedTime != nil && item.stepInfo.ElapsedTime.Seconds > 0 {
-				return util.SecondTimeFormat(item.stepInfo.ElapsedTime.Seconds)
-			}
-		} else {
-			if item.job.ElapsedTime != nil && item.job.ElapsedTime.Seconds > 0 {
-				return util.SecondTimeFormat(item.job.ElapsedTime.Seconds)
-			}
-		}
-
-		// Fallback to derived duration if elapsed time is unavailable.
-		if startTime.IsZero() || endTime.IsZero() {
-			return "-"
-		}
-		if startTime.Before(time.Now()) && endTime.After(startTime) {
-			duration := endTime.Sub(startTime)
-			return util.SecondTimeFormat(int64(duration.Seconds()))
-		}
+	startTime, startOK := validAccountingTime(timing.startTime)
+	endTime, endOK := validAccountingTime(timing.endTime)
+	// A persisted reversal is corrupt even when a stale elapsed field happens
+	// to be present. Never let that field hide the invalid timestamp pair.
+	if startOK && endOK && endTime.Before(startTime) {
+		return "unknown"
 	}
-	return ""
+
+	// The backend value is authoritative when present, including a valid zero
+	// duration for a job cancelled before it started. A malformed value is
+	// evidence of corrupt accounting data, not an invitation to fabricate a
+	// replacement duration from timestamps.
+	if timing.elapsed != nil {
+		seconds, ok := validElapsedSeconds(timing.elapsed)
+		if !ok {
+			return "unknown"
+		}
+		return util.SecondTimeFormat(seconds)
+	}
+
+	if !startOK || !endOK || endTime.Before(startTime) {
+		return "unknown"
+	}
+	return util.SecondTimeFormat(int64(endTime.Sub(startTime) / time.Second))
 }
 
 // Deadline (D)
@@ -409,25 +485,42 @@ func ProcessDeadline(item *JobOrStep) string {
 
 // EndTime (E)
 func ProcessEndTime(item *JobOrStep) string {
-	endTimeStr := "unknown"
-	var status protos.JobStatus
-	var startTime, endTime time.Time
-
-	if item.isStep {
-		status = item.stepInfo.Status
-		startTime = item.stepInfo.StartTime.AsTime()
-		endTime = item.stepInfo.EndTime.AsTime()
-	} else {
-		status = item.job.Status
-		startTime = item.job.StartTime.AsTime()
-		endTime = item.job.EndTime.AsTime()
+	timing := getAccountingTiming(item)
+	if timing.status == protos.JobStatus_Pending ||
+		timing.status == protos.JobStatus_Running {
+		return "unknown"
 	}
-	if status != protos.JobStatus_Pending && status != protos.JobStatus_Running {
-		if startTime.Before(time.Now()) && endTime.After(startTime) {
-			endTimeStr = endTime.In(time.Local).Format("2006-01-02 15:04:05")
+	if timing.status == protos.JobStatus_Completing {
+		startTime, startOK := validAccountingTime(timing.startTime)
+		endTime, endOK := validAccountingTime(timing.endTime)
+		if !startOK || !endOK || !startTime.Before(time.Now()) ||
+			!endTime.After(startTime) {
+			return "unknown"
 		}
+		return endTime.In(time.Local).Format("2006-01-02 15:04:05")
 	}
-	return endTimeStr
+	if !isTerminalAccountingStatus(timing.status) {
+		// Keep the historical predicted-end display for intermediate states
+		// such as Suspended and Starting. Pending and Running returned above.
+		startTime, startOK := validAccountingTime(timing.startTime)
+		endTime, endOK := validAccountingTime(timing.endTime)
+		if !startOK || !endOK || !startTime.Before(time.Now()) ||
+			!endTime.After(startTime) {
+			return "unknown"
+		}
+		return endTime.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	endTime, endOK := validAccountingTime(timing.endTime)
+	if !endOK {
+		return "unknown"
+	}
+	// A valid end timestamp is independently useful for accounting output.
+	// Only reject a reversal when both timestamps are present and valid.
+	if startTime, startOK := validAccountingTime(timing.startTime); startOK &&
+		endTime.Before(startTime) {
+		return "unknown"
+	}
+	return endTime.In(time.Local).Format("2006-01-02 15:04:05")
 }
 
 // ExitCode (e)
@@ -655,35 +748,22 @@ func ProcessReqNodes(item *JobOrStep) string {
 
 // StartTime (S)
 func ProcessStartTime(item *JobOrStep) string {
-	startTimeStr := "unknown"
-	var startTime time.Time
-	if item.isStep {
-		startTime = item.stepInfo.StartTime.AsTime()
-	} else {
-		startTime = item.job.StartTime.AsTime()
-	}
-
-	if !startTime.Before(time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)) &&
-		startTime.Before(time.Now()) {
-		startTimeStr = startTime.In(time.Local).Format("2006-01-02 15:04:05")
-	}
-	return startTimeStr
+	return formatAccountingTime(getAccountingTiming(item).startTime, true)
 }
 
 // SubmitTime (s)
 func ProcessSubmitTime(item *JobOrStep) string {
-	submitTimeStr := "unknown"
-	var submitTime time.Time
-	if item.isStep {
-		submitTime = item.stepInfo.SubmitTime.AsTime()
-	} else {
-		submitTime = item.job.SubmitTime.AsTime()
+	var timestamp *timestamppb.Timestamp
+	if item != nil {
+		if item.isStep {
+			if item.stepInfo != nil {
+				timestamp = item.stepInfo.SubmitTime
+			}
+		} else if item.job != nil {
+			timestamp = item.job.SubmitTime
+		}
 	}
-
-	if !submitTime.Before(time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)) {
-		submitTimeStr = submitTime.In(time.Local).Format("2006-01-02 15:04:05")
-	}
-	return submitTimeStr
+	return formatAccountingTime(timestamp, false)
 }
 
 // JobType (T)

--- a/internal/cacct/cacct.go
+++ b/internal/cacct/cacct.go
@@ -44,9 +44,6 @@ var (
 const (
 	kTerminationSignalBase = 256
 	kCraneExitCodeBase     = 320
-	// Keep this aligned with google.protobuf.util.TimeUtil's timestamp max;
-	// the backend uses that exact second as the unset/future sentinel.
-	kAccountingMaxTimestampSeconds int64 = 253402300799
 )
 
 // QueryJob will query all pending, running and completed jobs.
@@ -325,79 +322,33 @@ type accountingTiming struct {
 	endTime   *timestamppb.Timestamp
 }
 
-func getAccountingTiming(item *JobOrStep) accountingTiming {
+func getAccountingTiming(item *JobOrStep) (accountingTiming, bool) {
 	if item == nil {
-		return accountingTiming{}
+		return accountingTiming{}, false
 	}
 	if item.isStep {
 		if item.stepInfo == nil {
-			return accountingTiming{}
+			return accountingTiming{}, false
 		}
-		return accountingTiming{
-			status:    item.stepInfo.Status,
-			elapsed:   item.stepInfo.ElapsedTime,
-			startTime: item.stepInfo.StartTime,
-			endTime:   item.stepInfo.EndTime,
-		}
+		return accountingTiming{item.stepInfo.Status, item.stepInfo.ElapsedTime,
+			item.stepInfo.StartTime, item.stepInfo.EndTime}, true
 	}
 	if item.job == nil {
-		return accountingTiming{}
+		return accountingTiming{}, false
 	}
-	return accountingTiming{
-		status:    item.job.Status,
-		elapsed:   item.job.ElapsedTime,
-		startTime: item.job.StartTime,
-		endTime:   item.job.EndTime,
-	}
+	return accountingTiming{item.job.Status, item.job.ElapsedTime,
+		item.job.StartTime, item.job.EndTime}, true
 }
 
 func isTerminalAccountingStatus(status protos.JobStatus) bool {
 	switch status {
-	case protos.JobStatus_Completed,
-		protos.JobStatus_Failed,
-		protos.JobStatus_ExceedTimeLimit,
-		protos.JobStatus_Cancelled,
-		protos.JobStatus_OutOfMemory,
-		protos.JobStatus_Deadline:
+	case protos.JobStatus_Completed, protos.JobStatus_Failed,
+		protos.JobStatus_Cancelled, protos.JobStatus_ExceedTimeLimit,
+		protos.JobStatus_OutOfMemory, protos.JobStatus_Deadline:
 		return true
 	default:
 		return false
 	}
-}
-
-func validAccountingTime(timestamp *timestamppb.Timestamp) (time.Time, bool) {
-	if timestamp == nil || !timestamp.IsValid() ||
-		(timestamp.Seconds == 0 && timestamp.Nanos == 0) {
-		return time.Time{}, false
-	}
-	if timestamp.Seconds >= kAccountingMaxTimestampSeconds {
-		return time.Time{}, false
-	}
-	timestampTime := timestamp.AsTime()
-	accountingEpoch := time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
-	// The protobuf timestamp maximum is the backend's unset/future sentinel,
-	// not a real accounting event.
-	if timestampTime.Before(accountingEpoch) {
-		return time.Time{}, false
-	}
-	return timestampTime, true
-}
-
-func validElapsedSeconds(duration *durationpb.Duration) (int64, bool) {
-	if duration == nil || !duration.IsValid() || duration.Seconds < 0 ||
-		duration.Nanos < 0 {
-		return 0, false
-	}
-	return duration.Seconds, true
-}
-
-func formatAccountingTime(timestamp *timestamppb.Timestamp,
-	requirePast bool) string {
-	value, ok := validAccountingTime(timestamp)
-	if !ok || (requirePast && value.After(time.Now())) {
-		return "unknown"
-	}
-	return value.In(time.Local).Format("2006-01-02 15:04:05")
 }
 
 type FieldProcessor struct {
@@ -437,9 +388,12 @@ func ProcessAllocCPUs(item *JobOrStep) string {
 
 // ElapsedTime (D)
 func ProcessElapsedTime(item *JobOrStep) string {
-	timing := getAccountingTiming(item)
+	timing, ok := getAccountingTiming(item)
+	if !ok {
+		return "unknown"
+	}
 	if timing.status == protos.JobStatus_Running {
-		if seconds, ok := validElapsedSeconds(timing.elapsed); ok {
+		if seconds, valid := util.ValidDurationSeconds(timing.elapsed); valid {
 			return util.SecondTimeFormat(seconds)
 		}
 		return ""
@@ -448,27 +402,15 @@ func ProcessElapsedTime(item *JobOrStep) string {
 		return ""
 	}
 
-	startTime, startOK := validAccountingTime(timing.startTime)
-	endTime, endOK := validAccountingTime(timing.endTime)
-	// A persisted reversal is corrupt even when a stale elapsed field happens
-	// to be present. Never let that field hide the invalid timestamp pair.
+	startTime, startOK := util.ParseCraneTimestamp(timing.startTime)
+	endTime, endOK := util.ParseCraneTimestamp(timing.endTime)
 	if startOK && endOK && endTime.Before(startTime) {
 		return "unknown"
 	}
-
-	// The backend value is authoritative when present, including a valid zero
-	// duration for a job cancelled before it started. A malformed value is
-	// evidence of corrupt accounting data, not an invitation to fabricate a
-	// replacement duration from timestamps.
-	if timing.elapsed != nil {
-		seconds, ok := validElapsedSeconds(timing.elapsed)
-		if !ok {
-			return "unknown"
-		}
+	if seconds, valid := util.ValidDurationSeconds(timing.elapsed); valid {
 		return util.SecondTimeFormat(seconds)
 	}
-
-	if !startOK || !endOK || endTime.Before(startTime) {
+	if timing.elapsed != nil || !startOK || !endOK {
 		return "unknown"
 	}
 	return util.SecondTimeFormat(int64(endTime.Sub(startTime) / time.Second))
@@ -485,39 +427,21 @@ func ProcessDeadline(item *JobOrStep) string {
 
 // EndTime (E)
 func ProcessEndTime(item *JobOrStep) string {
-	timing := getAccountingTiming(item)
-	if timing.status == protos.JobStatus_Pending ||
+	timing, ok := getAccountingTiming(item)
+	if !ok || timing.status == protos.JobStatus_Pending ||
 		timing.status == protos.JobStatus_Running {
 		return "unknown"
 	}
-	if timing.status == protos.JobStatus_Completing {
-		startTime, startOK := validAccountingTime(timing.startTime)
-		endTime, endOK := validAccountingTime(timing.endTime)
-		if !startOK || !endOK || !startTime.Before(time.Now()) ||
-			!endTime.After(startTime) {
-			return "unknown"
-		}
-		return endTime.In(time.Local).Format("2006-01-02 15:04:05")
-	}
-	if !isTerminalAccountingStatus(timing.status) {
-		// Keep the historical predicted-end display for intermediate states
-		// such as Suspended and Starting. Pending and Running returned above.
-		startTime, startOK := validAccountingTime(timing.startTime)
-		endTime, endOK := validAccountingTime(timing.endTime)
-		if !startOK || !endOK || !startTime.Before(time.Now()) ||
-			!endTime.After(startTime) {
-			return "unknown"
-		}
-		return endTime.In(time.Local).Format("2006-01-02 15:04:05")
-	}
-	endTime, endOK := validAccountingTime(timing.endTime)
+	endTime, endOK := util.ParseCraneTimestamp(timing.endTime)
 	if !endOK {
 		return "unknown"
 	}
-	// A valid end timestamp is independently useful for accounting output.
-	// Only reject a reversal when both timestamps are present and valid.
-	if startTime, startOK := validAccountingTime(timing.startTime); startOK &&
-		endTime.Before(startTime) {
+	startTime, startOK := util.ParseCraneTimestamp(timing.startTime)
+	if !startOK || endTime.Before(startTime) {
+		return "unknown"
+	}
+	if !isTerminalAccountingStatus(timing.status) &&
+		(!startTime.Before(time.Now()) || !endTime.After(startTime)) {
 		return "unknown"
 	}
 	return endTime.In(time.Local).Format("2006-01-02 15:04:05")
@@ -748,22 +672,35 @@ func ProcessReqNodes(item *JobOrStep) string {
 
 // StartTime (S)
 func ProcessStartTime(item *JobOrStep) string {
-	return formatAccountingTime(getAccountingTiming(item).startTime, true)
+	startTimeStr := "unknown"
+	var startTime time.Time
+	if item.isStep {
+		startTime = item.stepInfo.StartTime.AsTime()
+	} else {
+		startTime = item.job.StartTime.AsTime()
+	}
+
+	if !startTime.Before(time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)) &&
+		startTime.Before(time.Now()) {
+		startTimeStr = startTime.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return startTimeStr
 }
 
 // SubmitTime (s)
 func ProcessSubmitTime(item *JobOrStep) string {
-	var timestamp *timestamppb.Timestamp
-	if item != nil {
-		if item.isStep {
-			if item.stepInfo != nil {
-				timestamp = item.stepInfo.SubmitTime
-			}
-		} else if item.job != nil {
-			timestamp = item.job.SubmitTime
-		}
+	submitTimeStr := "unknown"
+	var submitTime time.Time
+	if item.isStep {
+		submitTime = item.stepInfo.SubmitTime.AsTime()
+	} else {
+		submitTime = item.job.SubmitTime.AsTime()
 	}
-	return formatAccountingTime(timestamp, false)
+
+	if !submitTime.Before(time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		submitTimeStr = submitTime.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return submitTimeStr
 }
 
 // JobType (T)

--- a/internal/cacct/cacct_test.go
+++ b/internal/cacct/cacct_test.go
@@ -10,31 +10,25 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func accountingTimestamp(seconds int64) *timestamppb.Timestamp {
-	return timestamppb.New(time.Unix(seconds, 0).UTC())
+func testTimestamp(seconds int64) *timestamppb.Timestamp {
+	return timestamppb.New(time.Unix(seconds, 0))
 }
 
-func accountingJob(status protos.JobStatus, start, end int64,
+func testAccountingItem(step bool, status protos.JobStatus, start, end int64,
 	elapsed *durationpb.Duration) *JobOrStep {
+	if step {
+		return &JobOrStep{isStep: true, stepInfo: &protos.StepInfo{
+			Status: status, StartTime: testTimestamp(start),
+			EndTime: testTimestamp(end), ElapsedTime: elapsed,
+		}}
+	}
 	return &JobOrStep{job: &protos.JobInfo{
-		Status:      status,
-		StartTime:   accountingTimestamp(start),
-		EndTime:     accountingTimestamp(end),
-		ElapsedTime: elapsed,
-	}, isStep: false}
+		Status: status, StartTime: testTimestamp(start),
+		EndTime: testTimestamp(end), ElapsedTime: elapsed,
+	}}
 }
 
-func accountingStep(status protos.JobStatus, start, end int64,
-	elapsed *durationpb.Duration) *JobOrStep {
-	return &JobOrStep{stepInfo: &protos.StepInfo{
-		Status:      status,
-		StartTime:   accountingTimestamp(start),
-		EndTime:     accountingTimestamp(end),
-		ElapsedTime: elapsed,
-	}, isStep: true}
-}
-
-func TestProcessAccountingTerminalElapsed(t *testing.T) {
+func TestTerminalAccountingTimes(t *testing.T) {
 	const start = int64(1_700_000_000)
 	statuses := []protos.JobStatus{
 		protos.JobStatus_Completed,
@@ -45,147 +39,112 @@ func TestProcessAccountingTerminalElapsed(t *testing.T) {
 		protos.JobStatus_Deadline,
 	}
 	for _, status := range statuses {
-		if got, ok := validAccountingTime(accountingTimestamp(start)); !ok {
-			t.Fatalf("timestamp invalid: %v", got)
-		}
-		for _, item := range []*JobOrStep{
-			accountingJob(status, start, start+5, nil),
-			accountingStep(status, start, start+5, nil),
-		} {
+		for _, step := range []bool{false, true} {
+			item := testAccountingItem(step, status, start, start+5, nil)
 			if got := ProcessElapsedTime(item); got != "00:00:05" {
-				t.Errorf("status %v elapsed = %q, want 00:00:05", status, got)
+				t.Errorf("status=%v step=%v elapsed=%q", status, step, got)
 			}
 			if got := ProcessEndTime(item); got == "unknown" {
-				t.Errorf("status %v end time was unknown", status)
+				t.Errorf("status=%v step=%v end time is unknown", status, step)
 			}
 		}
 	}
 }
 
-func TestProcessAccountingZeroElapsedAndBackendPreference(t *testing.T) {
+func TestTerminalAccountingAllowsZeroAndPrefersBackendElapsed(t *testing.T) {
 	const start = int64(1_700_000_000)
-	item := accountingJob(protos.JobStatus_Cancelled, start, start,
-		durationpb.New(0))
-	if got := ProcessElapsedTime(item); got != "00:00:00" {
-		t.Fatalf("zero backend elapsed = %q, want 00:00:00", got)
-	}
-	if got := ProcessEndTime(item); got == "unknown" {
-		t.Fatal("equal start/end must still display an end time")
-	}
-	step := accountingStep(protos.JobStatus_Cancelled, start, start,
-		durationpb.New(0))
-	if got := ProcessElapsedTime(step); got != "00:00:00" {
-		t.Fatalf("zero step elapsed = %q, want 00:00:00", got)
-	}
-	if got := ProcessEndTime(step); got == "unknown" {
-		t.Fatal("equal step start/end must still display an end time")
+	for _, step := range []bool{false, true} {
+		item := testAccountingItem(step, protos.JobStatus_Cancelled, start, start,
+			durationpb.New(0))
+		if got := ProcessElapsedTime(item); got != "00:00:00" {
+			t.Errorf("step=%v zero elapsed=%q", step, got)
+		}
+		if got := ProcessEndTime(item); got == "unknown" {
+			t.Errorf("step=%v zero-duration end time is unknown", step)
+		}
 	}
 
-	item = accountingStep(protos.JobStatus_Failed, start, start+5,
+	item := testAccountingItem(false, protos.JobStatus_Failed, start, start+5,
 		durationpb.New(7*time.Second))
 	if got := ProcessElapsedTime(item); got != "00:00:07" {
-		t.Fatalf("backend elapsed = %q, want 00:00:07", got)
-	}
-	item.stepInfo.ElapsedTime = &durationpb.Duration{Seconds: 1, Nanos: -1}
-	if got := ProcessElapsedTime(item); got != "unknown" {
-		t.Fatalf("invalid backend elapsed = %q, want unknown", got)
+		t.Fatalf("backend elapsed=%q", got)
 	}
 }
 
-func TestProcessAccountingRejectsMissingAndReversedTimes(t *testing.T) {
+func TestTerminalAccountingRejectsInvalidTimes(t *testing.T) {
 	const start = int64(1_700_000_000)
-	reversed := accountingJob(protos.JobStatus_Failed, start+5, start, nil)
-	if got := ProcessElapsedTime(reversed); got != "unknown" {
-		t.Fatalf("reversed elapsed = %q, want unknown", got)
+	tests := []struct {
+		name string
+		item *JobOrStep
+	}{
+		{
+			name: "reverse",
+			item: testAccountingItem(false, protos.JobStatus_Failed,
+				start+5, start, durationpb.New(5*time.Second)),
+		},
+		{
+			name: "missing both",
+			item: &JobOrStep{job: &protos.JobInfo{
+				Status: protos.JobStatus_Completed,
+			}},
+		},
+		{
+			name: "missing end",
+			item: &JobOrStep{job: &protos.JobInfo{
+				Status: protos.JobStatus_Completed, StartTime: testTimestamp(start),
+			}},
+		},
+		{
+			name: "missing start",
+			item: &JobOrStep{job: &protos.JobInfo{
+				Status: protos.JobStatus_Completed, EndTime: testTimestamp(start + 5),
+			}},
+		},
+		{
+			name: "invalid timestamp",
+			item: &JobOrStep{job: &protos.JobInfo{
+				Status:    protos.JobStatus_Completed,
+				StartTime: &timestamppb.Timestamp{Seconds: start, Nanos: int32(time.Second)},
+				EndTime:   testTimestamp(start + 5),
+			}},
+		},
+		{
+			name: "invalid elapsed",
+			item: testAccountingItem(false, protos.JobStatus_Failed,
+				start, start+5, &durationpb.Duration{Seconds: 1, Nanos: -1}),
+		},
 	}
-	if got := ProcessEndTime(reversed); got != "unknown" {
-		t.Fatalf("reversed end time = %q, want unknown", got)
-	}
-	reversed.job.ElapsedTime = durationpb.New(5 * time.Second)
-	if got := ProcessElapsedTime(reversed); got != "unknown" {
-		t.Fatalf("reversed elapsed with backend value = %q, want unknown", got)
-	}
-
-	missing := &JobOrStep{job: &protos.JobInfo{
-		Status:    protos.JobStatus_Completed,
-		StartTime: accountingTimestamp(start),
-	}}
-	if got := ProcessElapsedTime(missing); got != "unknown" {
-		t.Fatalf("missing elapsed = %q, want unknown", got)
-	}
-	if got := ProcessEndTime(missing); got != "unknown" {
-		t.Fatalf("missing end time = %q, want unknown", got)
-	}
-}
-
-func TestProcessAccountingUsesValidZeroWithoutTimestamps(t *testing.T) {
-	item := &JobOrStep{job: &protos.JobInfo{
-		Status:      protos.JobStatus_Cancelled,
-		ElapsedTime: durationpb.New(0),
-	}}
-	if got := ProcessElapsedTime(item); got != "00:00:00" {
-		t.Fatalf("zero elapsed without timestamps = %q, want 00:00:00", got)
-	}
-}
-
-func TestProcessEndTimeUsesValidEndWithoutStart(t *testing.T) {
-	item := &JobOrStep{job: &protos.JobInfo{
-		Status:  protos.JobStatus_Failed,
-		EndTime: accountingTimestamp(1_700_000_005),
-	}}
-	if got := ProcessEndTime(item); got == "unknown" {
-		t.Fatal("valid terminal end time should be displayed when start is missing")
-	}
-}
-
-func TestProcessEndTimePreservesCompletingSemantics(t *testing.T) {
-	item := accountingJob(protos.JobStatus_Completing, 1_700_000_000,
-		1_700_000_005, nil)
-	if got := ProcessEndTime(item); got == "unknown" {
-		t.Fatal("completing end time should be displayed")
-	}
-	item = accountingJob(protos.JobStatus_Completing, 1_700_000_000,
-		1_700_000_000, nil)
-	if got := ProcessEndTime(item); got != "unknown" {
-		t.Fatalf("zero completing end time = %q, want unknown", got)
-	}
-}
-
-func TestProcessStartAndSubmitTimeHandleMissingTimestamps(t *testing.T) {
-	item := &JobOrStep{job: &protos.JobInfo{Status: protos.JobStatus_Failed}}
-	if got := ProcessStartTime(item); got != "unknown" {
-		t.Fatalf("missing start time = %q, want unknown", got)
-	}
-	if got := ProcessSubmitTime(item); got != "unknown" {
-		t.Fatalf("missing submit time = %q, want unknown", got)
-	}
-}
-
-func TestProcessAccountingRejectsInvalidAndEarlyTimestamps(t *testing.T) {
-	const start = int64(1_700_000_000)
-	for name, endTime := range map[string]*timestamppb.Timestamp{
-		"invalid": {Seconds: start, Nanos: int32(time.Second)},
-		"early":   accountingTimestamp(time.Date(1979, 12, 31, 0, 0, 0, 0, time.UTC).Unix()),
-	} {
-		t.Run(name, func(t *testing.T) {
-			item := accountingJob(protos.JobStatus_Failed, start, start, nil)
-			item.job.EndTime = endTime
-			if got := ProcessElapsedTime(item); got != "unknown" {
-				t.Fatalf("elapsed = %q, want unknown", got)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ProcessElapsedTime(test.item); got != "unknown" {
+				t.Errorf("elapsed=%q", got)
 			}
-			if got := ProcessEndTime(item); got != "unknown" {
-				t.Fatalf("end time = %q, want unknown", got)
+			if test.name != "invalid elapsed" {
+				if got := ProcessEndTime(test.item); got != "unknown" {
+					t.Errorf("end time=%q", got)
+				}
 			}
 		})
 	}
 }
 
-func TestProcessAccountingSubsecondFallback(t *testing.T) {
-	const seconds = int64(1_700_000_000)
-	item := accountingJob(protos.JobStatus_Completed, seconds, seconds, nil)
-	item.job.StartTime = timestamppb.New(time.Unix(seconds, int64(100*time.Millisecond)))
-	item.job.EndTime = timestamppb.New(time.Unix(seconds, int64(900*time.Millisecond)))
-	if got := ProcessElapsedTime(item); got != "00:00:00" {
-		t.Fatalf("subsecond elapsed = %q, want 00:00:00", got)
+func TestAccountingNonTerminalBehavior(t *testing.T) {
+	const start = int64(1_700_000_000)
+	running := testAccountingItem(false, protos.JobStatus_Running, start,
+		start+10, durationpb.New(3*time.Second))
+	if got := ProcessElapsedTime(running); got != "00:00:03" {
+		t.Fatalf("running elapsed=%q", got)
+	}
+	if got := ProcessEndTime(running); got != "unknown" {
+		t.Fatalf("running end time=%q", got)
+	}
+
+	pending := testAccountingItem(false, protos.JobStatus_Pending, start,
+		start+10, nil)
+	if got := ProcessElapsedTime(pending); got != "" {
+		t.Fatalf("pending elapsed=%q", got)
+	}
+	if got := ProcessEndTime(pending); got != "unknown" {
+		t.Fatalf("pending end time=%q", got)
 	}
 }

--- a/internal/cacct/cacct_test.go
+++ b/internal/cacct/cacct_test.go
@@ -1,0 +1,191 @@
+package cacct
+
+import (
+	"testing"
+	"time"
+
+	"CraneFrontEnd/generated/protos"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func accountingTimestamp(seconds int64) *timestamppb.Timestamp {
+	return timestamppb.New(time.Unix(seconds, 0).UTC())
+}
+
+func accountingJob(status protos.JobStatus, start, end int64,
+	elapsed *durationpb.Duration) *JobOrStep {
+	return &JobOrStep{job: &protos.JobInfo{
+		Status:      status,
+		StartTime:   accountingTimestamp(start),
+		EndTime:     accountingTimestamp(end),
+		ElapsedTime: elapsed,
+	}, isStep: false}
+}
+
+func accountingStep(status protos.JobStatus, start, end int64,
+	elapsed *durationpb.Duration) *JobOrStep {
+	return &JobOrStep{stepInfo: &protos.StepInfo{
+		Status:      status,
+		StartTime:   accountingTimestamp(start),
+		EndTime:     accountingTimestamp(end),
+		ElapsedTime: elapsed,
+	}, isStep: true}
+}
+
+func TestProcessAccountingTerminalElapsed(t *testing.T) {
+	const start = int64(1_700_000_000)
+	statuses := []protos.JobStatus{
+		protos.JobStatus_Completed,
+		protos.JobStatus_Failed,
+		protos.JobStatus_Cancelled,
+		protos.JobStatus_ExceedTimeLimit,
+		protos.JobStatus_OutOfMemory,
+		protos.JobStatus_Deadline,
+	}
+	for _, status := range statuses {
+		if got, ok := validAccountingTime(accountingTimestamp(start)); !ok {
+			t.Fatalf("timestamp invalid: %v", got)
+		}
+		for _, item := range []*JobOrStep{
+			accountingJob(status, start, start+5, nil),
+			accountingStep(status, start, start+5, nil),
+		} {
+			if got := ProcessElapsedTime(item); got != "00:00:05" {
+				t.Errorf("status %v elapsed = %q, want 00:00:05", status, got)
+			}
+			if got := ProcessEndTime(item); got == "unknown" {
+				t.Errorf("status %v end time was unknown", status)
+			}
+		}
+	}
+}
+
+func TestProcessAccountingZeroElapsedAndBackendPreference(t *testing.T) {
+	const start = int64(1_700_000_000)
+	item := accountingJob(protos.JobStatus_Cancelled, start, start,
+		durationpb.New(0))
+	if got := ProcessElapsedTime(item); got != "00:00:00" {
+		t.Fatalf("zero backend elapsed = %q, want 00:00:00", got)
+	}
+	if got := ProcessEndTime(item); got == "unknown" {
+		t.Fatal("equal start/end must still display an end time")
+	}
+	step := accountingStep(protos.JobStatus_Cancelled, start, start,
+		durationpb.New(0))
+	if got := ProcessElapsedTime(step); got != "00:00:00" {
+		t.Fatalf("zero step elapsed = %q, want 00:00:00", got)
+	}
+	if got := ProcessEndTime(step); got == "unknown" {
+		t.Fatal("equal step start/end must still display an end time")
+	}
+
+	item = accountingStep(protos.JobStatus_Failed, start, start+5,
+		durationpb.New(7*time.Second))
+	if got := ProcessElapsedTime(item); got != "00:00:07" {
+		t.Fatalf("backend elapsed = %q, want 00:00:07", got)
+	}
+	item.stepInfo.ElapsedTime = &durationpb.Duration{Seconds: 1, Nanos: -1}
+	if got := ProcessElapsedTime(item); got != "unknown" {
+		t.Fatalf("invalid backend elapsed = %q, want unknown", got)
+	}
+}
+
+func TestProcessAccountingRejectsMissingAndReversedTimes(t *testing.T) {
+	const start = int64(1_700_000_000)
+	reversed := accountingJob(protos.JobStatus_Failed, start+5, start, nil)
+	if got := ProcessElapsedTime(reversed); got != "unknown" {
+		t.Fatalf("reversed elapsed = %q, want unknown", got)
+	}
+	if got := ProcessEndTime(reversed); got != "unknown" {
+		t.Fatalf("reversed end time = %q, want unknown", got)
+	}
+	reversed.job.ElapsedTime = durationpb.New(5 * time.Second)
+	if got := ProcessElapsedTime(reversed); got != "unknown" {
+		t.Fatalf("reversed elapsed with backend value = %q, want unknown", got)
+	}
+
+	missing := &JobOrStep{job: &protos.JobInfo{
+		Status:    protos.JobStatus_Completed,
+		StartTime: accountingTimestamp(start),
+	}}
+	if got := ProcessElapsedTime(missing); got != "unknown" {
+		t.Fatalf("missing elapsed = %q, want unknown", got)
+	}
+	if got := ProcessEndTime(missing); got != "unknown" {
+		t.Fatalf("missing end time = %q, want unknown", got)
+	}
+}
+
+func TestProcessAccountingUsesValidZeroWithoutTimestamps(t *testing.T) {
+	item := &JobOrStep{job: &protos.JobInfo{
+		Status:      protos.JobStatus_Cancelled,
+		ElapsedTime: durationpb.New(0),
+	}}
+	if got := ProcessElapsedTime(item); got != "00:00:00" {
+		t.Fatalf("zero elapsed without timestamps = %q, want 00:00:00", got)
+	}
+}
+
+func TestProcessEndTimeUsesValidEndWithoutStart(t *testing.T) {
+	item := &JobOrStep{job: &protos.JobInfo{
+		Status:  protos.JobStatus_Failed,
+		EndTime: accountingTimestamp(1_700_000_005),
+	}}
+	if got := ProcessEndTime(item); got == "unknown" {
+		t.Fatal("valid terminal end time should be displayed when start is missing")
+	}
+}
+
+func TestProcessEndTimePreservesCompletingSemantics(t *testing.T) {
+	item := accountingJob(protos.JobStatus_Completing, 1_700_000_000,
+		1_700_000_005, nil)
+	if got := ProcessEndTime(item); got == "unknown" {
+		t.Fatal("completing end time should be displayed")
+	}
+	item = accountingJob(protos.JobStatus_Completing, 1_700_000_000,
+		1_700_000_000, nil)
+	if got := ProcessEndTime(item); got != "unknown" {
+		t.Fatalf("zero completing end time = %q, want unknown", got)
+	}
+}
+
+func TestProcessStartAndSubmitTimeHandleMissingTimestamps(t *testing.T) {
+	item := &JobOrStep{job: &protos.JobInfo{Status: protos.JobStatus_Failed}}
+	if got := ProcessStartTime(item); got != "unknown" {
+		t.Fatalf("missing start time = %q, want unknown", got)
+	}
+	if got := ProcessSubmitTime(item); got != "unknown" {
+		t.Fatalf("missing submit time = %q, want unknown", got)
+	}
+}
+
+func TestProcessAccountingRejectsInvalidAndEarlyTimestamps(t *testing.T) {
+	const start = int64(1_700_000_000)
+	for name, endTime := range map[string]*timestamppb.Timestamp{
+		"invalid": {Seconds: start, Nanos: int32(time.Second)},
+		"early":   accountingTimestamp(time.Date(1979, 12, 31, 0, 0, 0, 0, time.UTC).Unix()),
+	} {
+		t.Run(name, func(t *testing.T) {
+			item := accountingJob(protos.JobStatus_Failed, start, start, nil)
+			item.job.EndTime = endTime
+			if got := ProcessElapsedTime(item); got != "unknown" {
+				t.Fatalf("elapsed = %q, want unknown", got)
+			}
+			if got := ProcessEndTime(item); got != "unknown" {
+				t.Fatalf("end time = %q, want unknown", got)
+			}
+		})
+	}
+}
+
+func TestProcessAccountingSubsecondFallback(t *testing.T) {
+	const seconds = int64(1_700_000_000)
+	item := accountingJob(protos.JobStatus_Completed, seconds, seconds, nil)
+	item.job.StartTime = timestamppb.New(time.Unix(seconds, int64(100*time.Millisecond)))
+	item.job.EndTime = timestamppb.New(time.Unix(seconds, int64(900*time.Millisecond)))
+	if got := ProcessElapsedTime(item); got != "00:00:00" {
+		t.Fatalf("subsecond elapsed = %q, want 00:00:00", got)
+	}
+}

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2024 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package util
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var earliestCraneTimestamp = time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func ParseCraneTimestamp(timestamp *timestamppb.Timestamp) (time.Time, bool) {
+	if timestamp == nil || !timestamp.IsValid() ||
+		timestamp.Seconds >= MaxJobTimeStamp {
+		return time.Time{}, false
+	}
+	value := timestamp.AsTime()
+	return value, !value.Before(earliestCraneTimestamp)
+}
+
+func ValidDurationSeconds(duration *durationpb.Duration) (int64, bool) {
+	if duration == nil || !duration.IsValid() || duration.AsDuration() < 0 {
+		return 0, false
+	}
+	return duration.Seconds, true
+}

--- a/internal/util/time_test.go
+++ b/internal/util/time_test.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestParseCraneTimestamp(t *testing.T) {
+	valid := timestamppb.New(time.Unix(1_700_000_000, 0))
+	if got, ok := ParseCraneTimestamp(valid); !ok || got.Unix() != valid.Seconds {
+		t.Fatalf("ParseCraneTimestamp() = (%v, %v)", got, ok)
+	}
+
+	for _, timestamp := range []*timestamppb.Timestamp{
+		nil,
+		{},
+		{Seconds: MaxJobTimeStamp},
+		{Seconds: valid.Seconds, Nanos: int32(time.Second)},
+	} {
+		if _, ok := ParseCraneTimestamp(timestamp); ok {
+			t.Fatalf("ParseCraneTimestamp(%v) unexpectedly succeeded", timestamp)
+		}
+	}
+}
+
+func TestValidDurationSeconds(t *testing.T) {
+	for _, test := range []struct {
+		duration *durationpb.Duration
+		want     int64
+		ok       bool
+	}{
+		{duration: durationpb.New(0), want: 0, ok: true},
+		{duration: durationpb.New(5 * time.Second), want: 5, ok: true},
+		{duration: durationpb.New(-time.Second), ok: false},
+		{duration: nil, ok: false},
+	} {
+		got, ok := ValidDurationSeconds(test.duration)
+		if got != test.want || ok != test.ok {
+			t.Errorf("ValidDurationSeconds(%v) = (%d, %v), want (%d, %v)",
+				test.duration, got, ok, test.want, test.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add shared protobuf timestamp/duration validation under `internal/util`
- show `ENDTIME` and `ELAPSEDTIME` consistently for Completed, Failed, Cancelled, ExceedTimeLimit, OutOfMemory, and Deadline jobs and steps
- prefer a valid Backend elapsed value, including zero, and otherwise derive it only from valid ordered timestamps
- display equal start/end timestamps as `00:00:00`; keep missing, invalid, and reversed intervals as `unknown`

## Scope

- keeps existing non-terminal, start-time, and submit-time display behavior
- uses one small job/step timing adapter in `cacct`

## Validation

- AutoTest Compose FrontEnd package build: passed
- `gofmt`: passed
- `go test -overlay=/tmp/pty-fe-overlay.json ./...`: passed
- `go test -race -overlay=/tmp/pty-fe-overlay.json ./...`: passed
- `git diff --check`: passed
