### PR TITLE
fix(crun): inherit batch memory for nested steps

### DIFF
--- a/internal/crun/crun.go
+++ b/internal/crun/crun.go
@@ -1702,21 +1702,9 @@ func MainCrun(cmd *cobra.Command, args []string) error {
 			Env: make(map[string]string), TaskProlog: FlagTaskProlog,
 			TaskEpilog: FlagTaskEpilog,
 		}
-		// Inherit from job environment variables
-		if ntasksStr, exists := syscall.Getenv("CRANE_NTASKS"); exists {
-			if ntasks, err := strconv.ParseUint(ntasksStr, 10, 32); err == nil {
-				step.Ntasks = uint32(ntasks)
-			}
-		}
-		if numNodesStr, exists := syscall.Getenv("CRANE_JOB_NUM_NODES"); exists {
-			if numNodes, err := strconv.ParseUint(numNodesStr, 10, 32); err == nil {
-				step.NodeNum = uint32(numNodes)
-			}
-		}
-		if ntasksPerNodeStr, exists := syscall.Getenv("CRANE_NTASKS_PER_NODE"); exists {
-			if ntasksPerNode, err := strconv.ParseUint(ntasksPerNodeStr, 10, 32); err == nil {
-				step.NtasksPerNode = uint32(ntasksPerNode)
-			}
+		inheritMemory := !cmd.Flags().Changed("mem") && !cmd.Flags().Changed("mem-per-cpu")
+		if err := setInheritedStepFieldsFromEnv(step, inheritMemory); err != nil {
+			return err
 		}
 	}
 

--- a/internal/crun/env.go
+++ b/internal/crun/env.go
@@ -24,136 +24,37 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
-
-	"github.com/gogo/protobuf/proto"
 )
 
-func SetFieldsFromEnv(job *protos.JobToCtld, step *protos.StepToCtld) error {
-	env := os.Environ()
-	for _, e := range env {
-		pair := strings.SplitN(e, "=", 2)
-		key := pair[0]
-		value := pair[1]
-		switch key {
-		case "CRANE_JOB_ID", "CRANE_JOBID":
-			jobId, err := strconv.ParseUint(value, 10, 32)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_JOB_ID from env")
-			}
-			step.JobId = uint32(jobId)
-		case "CRANE_ACCOUNT":
-			if job != nil {
-				job.Account = value
-			}
-		case "CRANE_CONF":
-			if FlagConfigFilePath != util.DefaultConfigPath {
-				FlagConfigFilePath = value
-			}
-		case "CRANE_CPUS_PER_TASK":
-			cpusPerTask, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_CPUS_PER_TASK from env")
-			}
-			if job != nil {
-				job.CpusPerTask = &cpusPerTask
-			} else {
-				step.CpusPerTask = &cpusPerTask
-			}
-
-		case "CRANE_EXCLUSIVE":
-			exclusive, err := strconv.ParseBool(value)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_EXCLUSIVE from env")
-			}
-			if job != nil {
-				job.Exclusive = exclusive
-			}
-		case "CRANE_EXPORT_ENV":
-			if job != nil {
-				job.Env["CRANE_EXPORT_ENV"] = FlagExport
-			} else {
-				step.Env["CRANE_EXPORT_ENV"] = FlagExport
-			}
-		case "CRANE_GRES":
-			gresMap, err := util.ParseGres(value)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_GRES from env")
-			}
-			if job != nil {
-				job.GresPerNode = gresMap
-			} else {
-				step.GresPerNode = gresMap
-			}
-		case "CRANE_JOB_NAME":
-			if job != nil {
-				job.Name = value
-			}
-		case "CRANE_JOB_NUM_NODES":
-			numNodes, err := strconv.ParseUint(value, 10, 32)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_JOB_NUM_NODES from env")
-			}
-			if job != nil {
-				job.NodeNumMin = uint32(numNodes)
-				job.NodeNumMax = uint32(numNodes)
-			} else {
-				step.NodeNum = uint32(numNodes)
-			}
-		case "CRANE_MEM_PER_NODE":
-			memPerNode, err := util.ParseMemStringAsByte(value)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_MEM_PER_NODE from env")
-			}
-			if job != nil {
-				job.MemPerNode = &memPerNode
-			} else {
-				step.MemPerNode = &memPerNode
-			}
-		case "CRANE_NTASKS_PER_NODE":
-			ntasksPerNode, err := strconv.ParseUint(value, 10, 32)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_NTASKS_PER_NODE from env")
-			}
-			if job != nil {
-				job.NtasksPerNode = uint32(ntasksPerNode)
-			} else {
-				step.NtasksPerNode = uint32(ntasksPerNode)
-			}
-		case "CRANE_OPEN_MODE":
-			var openModeAppend bool
-			switch value {
-			case util.OpenModeAppend:
-				openModeAppend = true
-			case util.OpenModeTruncate:
-				openModeAppend = false
-			default:
-				return fmt.Errorf("invalid CRANE_OPEN_MODE from env: must be either '%s' or '%s'", util.OpenModeAppend, util.OpenModeTruncate)
-			}
-			if job != nil {
-				job.GetIoMeta().OpenModeAppend = proto.Bool(openModeAppend)
-			} else {
-				step.GetIoMeta().OpenModeAppend = proto.Bool(openModeAppend)
-			}
-		case "CRANE_QOS":
-			if job != nil {
-				job.Qos = value
-			}
-		case "CRANE_RESERVATION":
-			if job != nil {
-				job.Reservation = value
-			}
-		case "CRANE_TIME_LIMIT":
-			seconds, err := util.ParseDurationStrToSeconds(FlagTime)
-			if err != nil {
-				return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_TIME_LIMIT from env")
-			}
-			if job != nil {
-				job.TimeLimit.Seconds = seconds
-			} else {
-				step.TimeLimit.Seconds = seconds
-			}
+func setInheritedStepFieldsFromEnv(step *protos.StepToCtld, inheritMemory bool) error {
+	if ntasksString, exists := os.LookupEnv("CRANE_NTASKS"); exists {
+		ntasks, err := strconv.ParseUint(ntasksString, 10, 32)
+		if err != nil {
+			return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_NTASKS from env")
 		}
+		step.Ntasks = uint32(ntasks)
+	}
+	if nodeCountString, exists := os.LookupEnv("CRANE_JOB_NUM_NODES"); exists {
+		nodeCount, err := strconv.ParseUint(nodeCountString, 10, 32)
+		if err != nil {
+			return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_JOB_NUM_NODES from env")
+		}
+		step.NodeNum = uint32(nodeCount)
+	}
+	if ntasksPerNodeString, exists := os.LookupEnv("CRANE_NTASKS_PER_NODE"); exists {
+		ntasksPerNode, err := strconv.ParseUint(ntasksPerNodeString, 10, 32)
+		if err != nil {
+			return util.NewCraneErr(util.ErrorInvalidFormat, "invalid CRANE_NTASKS_PER_NODE from env")
+		}
+		step.NtasksPerNode = uint32(ntasksPerNode)
+	}
+	if memoryPerNodeString, exists := os.LookupEnv("CRANE_MEM_PER_NODE"); exists && inheritMemory {
+		memoryPerNode, err := util.ParseMemStringAsByte(memoryPerNodeString)
+		if err != nil {
+			return util.NewCraneErr(util.ErrorInvalidFormat,
+				fmt.Sprintf("invalid CRANE_MEM_PER_NODE from env: %s", memoryPerNodeString))
+		}
+		step.MemPerNode = &memoryPerNode
 	}
 	return nil
 }

--- a/internal/crun/env_test.go
+++ b/internal/crun/env_test.go
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2026 Peking University and Peking University
+ * Changsha Institute for Computing and Digital Economy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+package crun
+
+import (
+	"CraneFrontEnd/generated/protos"
+	"testing"
+)
+
+func TestSetInheritedStepFieldsFromEnv(t *testing.T) {
+	t.Setenv("CRANE_NTASKS", "4")
+	t.Setenv("CRANE_JOB_NUM_NODES", "1")
+	t.Setenv("CRANE_NTASKS_PER_NODE", "4")
+	t.Setenv("CRANE_MEM_PER_NODE", "512M")
+
+	step := &protos.StepToCtld{}
+	if err := setInheritedStepFieldsFromEnv(step, true); err != nil {
+		t.Fatalf("set inherited fields: %v", err)
+	}
+
+	if step.Ntasks != 4 || step.NodeNum != 1 || step.NtasksPerNode != 4 {
+		t.Fatalf("unexpected topology: nodes=%d ntasks=%d ntasks_per_node=%d", step.NodeNum, step.Ntasks, step.NtasksPerNode)
+	}
+	if step.MemPerNode == nil || *step.MemPerNode != 512*1024*1024 {
+		t.Fatalf("unexpected memory: %v", step.MemPerNode)
+	}
+}
+
+func TestSetInheritedStepFieldsFromEnvRejectsInvalidMemory(t *testing.T) {
+	t.Setenv("CRANE_MEM_PER_NODE", "not-a-memory")
+
+	err := setInheritedStepFieldsFromEnv(&protos.StepToCtld{}, true)
+	if err == nil {
+		t.Fatal("expected invalid memory error")
+	}
+}
+
+func TestSetInheritedStepFieldsFromEnvSkipsMemoryWhenExplicitMemoryOptionIsSet(t *testing.T) {
+	t.Setenv("CRANE_MEM_PER_NODE", "512M")
+
+	step := &protos.StepToCtld{}
+	if err := setInheritedStepFieldsFromEnv(step, false); err != nil {
+		t.Fatalf("set inherited fields: %v", err)
+	}
+	if step.MemPerNode != nil {
+		t.Fatalf("unexpected inherited memory: %d", *step.MemPerNode)
+	}
+}
+
+func TestSetInheritedStepFieldsFromEnvRejectsInvalidTopology(t *testing.T) {
+	t.Setenv("CRANE_NTASKS", "not-a-number")
+
+	if err := setInheritedStepFieldsFromEnv(&protos.StepToCtld{}, true); err == nil {
+		t.Fatal("expected invalid topology error")
+	}
+}

--- a/internal/crun/env_test.go
+++ b/internal/crun/env_test.go
@@ -12,53 +12,157 @@ package crun
 
 import (
 	"CraneFrontEnd/generated/protos"
+	"CraneFrontEnd/internal/util"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"google.golang.org/grpc"
 )
 
-func TestSetInheritedStepFieldsFromEnv(t *testing.T) {
-	t.Setenv("CRANE_NTASKS", "4")
-	t.Setenv("CRANE_JOB_NUM_NODES", "1")
-	t.Setenv("CRANE_NTASKS_PER_NODE", "4")
-	t.Setenv("CRANE_MEM_PER_NODE", "512M")
-
-	step := &protos.StepToCtld{}
-	if err := setInheritedStepFieldsFromEnv(step, true); err != nil {
-		t.Fatalf("set inherited fields: %v", err)
-	}
-
-	if step.Ntasks != 4 || step.NodeNum != 1 || step.NtasksPerNode != 4 {
-		t.Fatalf("unexpected topology: nodes=%d ntasks=%d ntasks_per_node=%d", step.NodeNum, step.Ntasks, step.NtasksPerNode)
-	}
-	if step.MemPerNode == nil || *step.MemPerNode != 512*1024*1024 {
-		t.Fatalf("unexpected memory: %v", step.MemPerNode)
-	}
+type memoryRequestRecorder struct {
+	protos.UnimplementedCraneForeDServer
+	requests chan *protos.StreamCrunRequest
 }
 
-func TestSetInheritedStepFieldsFromEnvRejectsInvalidMemory(t *testing.T) {
-	t.Setenv("CRANE_MEM_PER_NODE", "not-a-memory")
-
-	err := setInheritedStepFieldsFromEnv(&protos.StepToCtld{}, true)
-	if err == nil {
-		t.Fatal("expected invalid memory error")
+func (server *memoryRequestRecorder) CrunStream(stream protos.CraneForeD_CrunStreamServer) error {
+	request, err := stream.Recv()
+	if err != nil {
+		return err
 	}
+	select {
+	case server.requests <- request:
+	case <-stream.Context().Done():
+		return stream.Context().Err()
+	}
+	return stream.Send(&protos.StreamCrunReply{
+		Type: protos.StreamCrunReply_STEP_ID_REPLY,
+		Payload: &protos.StreamCrunReply_PayloadStepIdReply{
+			PayloadStepIdReply: &protos.StreamCrunReply_StepIdReply{
+				Ok: false, FailureReason: "test captured submission",
+			},
+		},
+	})
 }
 
-func TestSetInheritedStepFieldsFromEnvSkipsMemoryWhenExplicitMemoryOptionIsSet(t *testing.T) {
-	t.Setenv("CRANE_MEM_PER_NODE", "512M")
-
-	step := &protos.StepToCtld{}
-	if err := setInheritedStepFieldsFromEnv(step, false); err != nil {
-		t.Fatalf("set inherited fields: %v", err)
+func TestCrunMemoryCommandProcess(t *testing.T) {
+	if os.Getenv("CRUN_MEMORY_TEST_PROCESS") != "1" {
+		return
 	}
-	if step.MemPerNode != nil {
-		t.Fatalf("unexpected inherited memory: %d", *step.MemPerNode)
+	for index, argument := range os.Args {
+		if argument == "--" {
+			RootCmd.SetArgs(os.Args[index+1:])
+			ParseCmdArgs()
+			return
+		}
 	}
+	t.Fatal("missing command argument separator")
 }
 
-func TestSetInheritedStepFieldsFromEnvRejectsInvalidTopology(t *testing.T) {
-	t.Setenv("CRANE_NTASKS", "not-a-number")
-
-	if err := setInheritedStepFieldsFromEnv(&protos.StepToCtld{}, true); err == nil {
-		t.Fatal("expected invalid topology error")
+func TestCrunMemorySubmission(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		env       []string
+		flags     []string
+		wantNode  uint64
+		wantCPU   uint64
+		wantError string
+		wantCode  int
+	}{
+		{name: "inherit_512M", env: []string{"CRANE_MEM_PER_NODE=512M"}, flags: []string{"--nodes=1", "--ntasks=4"}, wantNode: 536870912},
+		{name: "explicit_mem_overrides_env", env: []string{"CRANE_MEM_PER_NODE=512M"}, flags: []string{"--mem=100M"}, wantNode: 104857600},
+		{name: "explicit_mem_per_cpu_overrides_env", env: []string{"CRANE_MEM_PER_NODE=512M"}, flags: []string{"--mem-per-cpu=64M"}, wantCPU: 67108864},
+		{name: "explicit_mem_ignores_invalid_env", env: []string{"CRANE_MEM_PER_NODE=invalid"}, flags: []string{"--mem=100M"}, wantNode: 104857600},
+		{name: "explicit_mem_per_cpu_ignores_invalid_env", env: []string{"CRANE_MEM_PER_NODE=invalid"}, flags: []string{"--mem-per-cpu=64M"}, wantCPU: 67108864},
+		{name: "unset_memory_stays_unspecified"},
+		{name: "invalid_memory_rejected", env: []string{"CRANE_MEM_PER_NODE=invalid"}, wantError: "invalid CRANE_MEM_PER_NODE from env", wantCode: util.ErrorInvalidFormat},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			listener, err := net.Listen("unix", filepath.Join(directory, "s"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			recorder := &memoryRequestRecorder{requests: make(chan *protos.StreamCrunRequest, 1)}
+			server := grpc.NewServer()
+			protos.RegisterCraneForeDServer(server, recorder)
+			serveDone := make(chan error, 1)
+			go func() { serveDone <- server.Serve(listener) }()
+			t.Cleanup(func() {
+				server.Stop()
+				if err := <-serveDone; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+					t.Errorf("serve test cfored: %v", err)
+				}
+			})
+			configPath := filepath.Join(directory, "config.yaml")
+			config := fmt.Sprintf("CraneBaseDir: %q\nCranedCforedSockPath: s\nCraneCtldForInternalListenPort: 10013\n", directory)
+			if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+				t.Fatal(err)
+			}
+			executable, err := os.Executable()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			args := []string{"-test.run=^TestCrunMemoryCommandProcess$", "--", "--config", configPath}
+			args = append(args, test.flags...)
+			command := exec.CommandContext(ctx, executable, append(args, "hostname")...)
+			for _, variable := range os.Environ() {
+				if !strings.HasPrefix(variable, "CRANE_") && !strings.HasPrefix(variable, "CRUN_MEMORY_TEST_PROCESS=") {
+					command.Env = append(command.Env, variable)
+				}
+			}
+			command.Env = append(command.Env, "CRUN_MEMORY_TEST_PROCESS=1", "CRANE_NTASKS=4", "CRANE_JOB_NUM_NODES=1", "CRANE_NTASKS_PER_NODE=4")
+			command.Env = append(command.Env, "CRANE_JOB_ID=42")
+			command.Env = append(command.Env, test.env...)
+			output, err := command.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("crun timed out: %s", output)
+			}
+			wantCode := util.ErrorBackend
+			wantError := "test captured submission"
+			if test.wantError != "" {
+				wantCode, wantError = test.wantCode, test.wantError
+			}
+			var exitError *exec.ExitError
+			if !errors.As(err, &exitError) || exitError.ExitCode() != wantCode || !strings.Contains(string(output), wantError) {
+				t.Fatalf("crun error=%v output=%s; want exit=%d and %q", err, output, wantCode, wantError)
+			}
+			if test.wantError != "" {
+				select {
+				case request := <-recorder.requests:
+					t.Fatalf("invalid arguments reached cfored: %v", request)
+				default:
+				}
+				return
+			}
+			var request *protos.StreamCrunRequest
+			select {
+			case request = <-recorder.requests:
+			default:
+				t.Fatal("crun did not send a submission")
+			}
+			step := request.GetPayloadStepReq().GetStep()
+			if request.Type != protos.StreamCrunRequest_STEP_REQUEST || step == nil {
+				t.Fatalf("expected nested step submission, got %v", request)
+			}
+			if step.JobId != 42 || step.NodeNum != 1 || step.Ntasks != 4 || step.NtasksPerNode != 4 {
+				t.Fatalf("incorrect inherited job identity or topology: %v", step)
+			}
+			if step.GetMemPerNode() != test.wantNode || (step.MemPerNode != nil) != (test.wantNode != 0) {
+				t.Errorf("MemPerNode=%v (%d), want %d with presence=%t", step.MemPerNode, step.GetMemPerNode(), test.wantNode, test.wantNode != 0)
+			}
+			if step.GetMemPerCpu() != test.wantCPU || (step.MemPerCpu != nil) != (test.wantCPU != 0) {
+				t.Errorf("MemPerCpu=%v (%d), want %d with presence=%t", step.MemPerCpu, step.GetMemPerCpu(), test.wantCPU, test.wantCPU != 0)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- inherit `CRANE_MEM_PER_NODE` for nested `crun` steps
- keep explicit `--mem` and `--mem-per-cpu` ahead of inherited memory
- remove the unused broad environment helper and add focused validation

## Validation
- `GOWORK=off go test ./internal/crun ./internal/util/...`
- Harness k3s CRD end-to-end run with updated operator and Crane image
  - inherited step: `536870912` bytes
  - explicit `--mem=100M`: `104857600` bytes
  - explicit `--mem-per-cpu=64M`: `268435456` bytes total
  - all jobs and nested steps completed with exit code `0`
  - batch environment printed `CRANE_MEM_PER_NODE=512M`

Evidence is retained locally under `tmp/crun-mem-e2e-final-20260912/` in the Harness workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Step-mode jobs inherit task counts, node counts, tasks per node, and memory-per-node settings from the environment.
  - Explicit `--mem` and `--mem-per-cpu` options select the requested memory dimension instead of retaining the other inherited setting.

- **Bug Fixes**
  - Invalid inherited topology and memory values are rejected, including when explicit memory options are provided.

- **Tests**
  - Added end-to-end coverage for inheritance, overrides, invalid values, submitted job details, and command error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->